### PR TITLE
Shortens transfer times on large data transfers with sync connections

### DIFF
--- a/src/sgct/network.cpp
+++ b/src/sgct/network.cpp
@@ -47,8 +47,6 @@
 
 namespace {
     constexpr const int MaxNumberOfAttempts = 10;
-    // Ethernet's MTU is 1500, so let's get close to that
-    constexpr const int SocketBufferSize = 1408; // 1024 + 256 + 128
 
     constexpr const int MaxNetworkSyncFrameNumber = 10000;
 
@@ -271,34 +269,7 @@ void Network::setOptions(SGCT_SOCKET* socket) {
         throw Err(5006, fmt::format("Failed to set reuse address: {}", SGCT_ERRNO));
     }
 
-    if (type() == Network::ConnectionType::SyncConnection) {
-        const int bufferSize = SocketBufferSize;
-        int iResult = setsockopt(
-            *socket,
-            SOL_SOCKET,
-            SO_RCVBUF,
-            reinterpret_cast<const char*>(&bufferSize),
-            sizeof(bufferSize)
-        );
-        if (iResult == SOCKET_ERROR) {
-            throw Err(5007, fmt::format(
-                "Failed to set send buffer size to {}. {}", bufferSize, SGCT_ERRNO
-            ));
-        }
-        iResult = setsockopt(
-            *socket,
-            SOL_SOCKET,
-            SO_SNDBUF,
-            reinterpret_cast<const char*>(&bufferSize),
-            sizeof(bufferSize)
-        );
-        if (iResult == SOCKET_ERROR) {
-            throw Err(5008, fmt::format(
-                "Failed to set receive buffer size to {}. {}", bufferSize, SGCT_ERRNO
-            ));
-        }
-    }
-    else {
+    if (type() != Network::ConnectionType::SyncConnection) {
         // set on all connections types, cluster nodes sends data several times per
         // second so there is no need so send alive packages
         int iResult = setsockopt(
@@ -458,19 +429,22 @@ int Network::lastError() {
 }
 
 int Network::receiveData(SGCT_SOCKET& lsocket, char* buffer, int length, int flags) {
-    long iResult = 0;
     int attempts = 1;
+
+    #ifdef WIN32
+    int iResult = 0;
+    const auto sgctError = WSAEINTR;
+    #else
+    ssize_t iResult = 0;
+    const auto sgctError = EINTR;
+    #endif
 
     while (iResult < length) {
         long tmpRes = recv(lsocket, buffer + iResult, length - iResult, flags);
         if (tmpRes > 0) {
             iResult += tmpRes;
         }
-#ifdef WIN32
-        else if (SGCT_ERRNO == WSAEINTR && attempts <= MaxNumberOfAttempts) {
-#else
-        else if (SGCT_ERRNO == EINTR && attempts <= MaxNumberOfAttempts) {
-#endif
+        else if (SGCT_ERRNO == sgctError && attempts <= MaxNumberOfAttempts) {
             Log::Warning(fmt::format(
                 "Receiving data after interrupted system error (attempt {})", attempts
             ));


### PR DESCRIPTION
We stumbled upon the issue of suuuuper long transfer times on large data transfers with sync connections. This PR shortens that time by 3 orders of magnitude on large data transfers. Our limited testing concluded that these changes didn't affect transfer times on data of sizes smaller than the old socket buffer limit of 1408 bytes.


Co-authored-by: Jacob Molin <jacobmolin@users.noreply.github.com>