### PR TITLE
Remove option to ignore exceptions when reading meta

### DIFF
--- a/include/sgct/readconfig.h
+++ b/include/sgct/readconfig.h
@@ -44,12 +44,9 @@ SGCT_EXPORT [[noreturn]] void convertToSgctExceptionAndThrow(const std::string& 
 /**
  * Reads and returns meta information in the configuration file. Since meta is
  * non-critical, and is composed of only strings (blank by default), a Meta object is
- * always returned even if the source file does not contain any meta information. If
- * \p ignoreErrors is set to true, adherence to the JSON schema will be ignored and no
- * parsing exceptions will be thrown.
+ * always returned even if the source file does not contain any meta information.
  */
-SGCT_EXPORT [[nodiscard]] sgct::config::Meta readMeta(const std::string& filename,
-    bool ignoreErrors = true);
+SGCT_EXPORT [[nodiscard]] sgct::config::Meta readMeta(const std::string& filename);
 
 } // namespace sgct
 

--- a/src/readconfig.cpp
+++ b/src/readconfig.cpp
@@ -2737,14 +2737,11 @@ sgct::config::GeneratorVersion readConfigGenerator(const std::string& filename) 
     return genVersion;
 }
 
-sgct::config::Meta readMeta(const std::string& filename, bool ignoreErrors) {
+sgct::config::Meta readMeta(const std::string& filename) {
     assert(std::filesystem::path(filename).extension() == ".json");
 
     std::filesystem::path name = std::filesystem::absolute(filename);
     if (!std::filesystem::exists(name)) {
-        if (ignoreErrors) {
-            return sgct::config::Meta();
-        }
         throw Err(
             6081,
             fmt::format("Could not find configuration file: {}", name)
@@ -2764,14 +2761,10 @@ sgct::config::Meta readMeta(const std::string& filename, bool ignoreErrors) {
         }
     }
     catch (const std::runtime_error& e) {
-        if (!ignoreErrors) {
-            throw Err(6082, e.what());
-        }
+        throw Err(6082, e.what());
     }
     catch (const nlohmann::json::exception& e) {
-        if (!ignoreErrors) {
-            throw Err(6082, e.what());
-        }
+        throw Err(6082, e.what());
     }
 
     return sgct::config::Meta();


### PR DESCRIPTION
Used in the fix for OpenSpace issue#2976. Ignoring exceptions when reading meta could sometimes cause a crash.