### PR TITLE
Include and compile fixes

### DIFF
--- a/include/sgct/clustermanager.h
+++ b/include/sgct/clustermanager.h
@@ -142,7 +142,7 @@ private:
     ClusterManager& operator=(const ClusterManager&) = delete;
     ClusterManager& operator=(ClusterManager&&) = delete;
 
-    ~ClusterManager() = default;
+    ~ClusterManager();
 
     static ClusterManager* _instance;
 

--- a/include/sgct/freetype.h
+++ b/include/sgct/freetype.h
@@ -12,6 +12,8 @@
 #include <sgct/sgctexports.h>
 #include <sgct/math.h>
 
+#include <string>
+
 namespace sgct {
     class BaseViewport;
     class Window;

--- a/include/sgct/readconfig.h
+++ b/include/sgct/readconfig.h
@@ -36,7 +36,8 @@ SGCT_EXPORT bool loadFileAndSchemaThenValidate(const std::filesystem::path& conf
 SGCT_EXPORT bool validateConfigAgainstSchema(const std::string& stringifiedConfig,
     const std::string& stringifiedSchema, const std::filesystem::path& schemaDir);
 
-SGCT_EXPORT [[noreturn]] void convertToSgctExceptionAndThrow(
+// Putting noreturn after SGCT_EXPORT fails to build on msvc with dynamic linking.
+[[noreturn]] SGCT_EXPORT void convertToSgctExceptionAndThrow(
     const std::filesystem::path& schema, const std::string& validationTypeExplanation,
     const std::string& exceptionMessage);
 

--- a/include/sgct/window.h
+++ b/include/sgct/window.h
@@ -97,8 +97,8 @@ public:
 
     static void makeSharedContextCurrent();
 
-    Window() = default;
-    ~Window() = default;
+    Window();
+    ~Window();
 
     Window(const Window&) = delete;
     Window(Window&&) = delete;

--- a/src/clustermanager.cpp
+++ b/src/clustermanager.cpp
@@ -49,6 +49,8 @@ ClusterManager::ClusterManager(int clusterID) : _thisNodeId(clusterID) {
     _users.push_back(std::make_unique<User>("default"));
 }
 
+ClusterManager:: ~ClusterManager() = default;
+
 void ClusterManager::applyCluster(const config::Cluster& cluster) {
     ZoneScoped;
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <array>
 
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -91,6 +91,9 @@ bool Window::_isBarrierActive = false;
 bool Window::_isSwapGroupMaster = false;
 GLFWwindow* Window::_sharedHandle = nullptr;
 
+Window::Window() = default;
+Window::~Window() = default;
+
 void Window::applyWindow(const config::Window& window) {
     ZoneScoped;
 


### PR DESCRIPTION
Fixes a couple of missing includes, probably hidden by the PCH. 

Move some default constructors/destructors to the cpp file.
This is needed when we have a std::unique_ptr<Foo> there Foo is forward declared. 
The full type of Foo is needed when the class constructor/destructor is compiled...
This will probably not be an issue in a static build. 

MSVC wants to have `[[noreturn]]`  before  `SGCT_EXPORT`
obviously is only shows up if linking dynamically where  `SGCT_EXPORT` is not empty. 