### PR TITLE
modifications to allow Mac builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,15 @@ enable_testing()
 
 project(sgct VERSION 3.0.0)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+function(add_submodule name)
+  add_subdirectory(${name})
+endfunction()
 
 include(support/cmake/register_package.cmake)
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
@@ -24,8 +30,9 @@ list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_BINARY_DIR}/pkg
 )
 
+# set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15") - we want a more recent version
 if (APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+  find_package(fmt REQUIRED)  
   if (NOT CMAKE_OSX_ARCHITECTURES)
     set(CMAKE_OSX_ARCHITECTURES "x86_64")
   endif ()

--- a/apps/calibrator/main.cpp
+++ b/apps/calibrator/main.cpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 #include <numeric>
 #include <thread>
+#include <sgct/format_compat.h>
 
 namespace {
     struct {
@@ -351,7 +352,7 @@ void initializeBox() {
     ImageData front;
     front.filename = "test-pattern-0.png";
     if (!std::filesystem::exists(front.filename)) {
-        Log::Error(std::format("Could not find image '{}'", front.filename));
+        Log::Error(sgctcompat::format("Could not find image '{}'", front.filename));
         exit(EXIT_FAILURE);
     }
     std::thread t1(loadImage, std::ref(front));
@@ -359,7 +360,7 @@ void initializeBox() {
     ImageData right;
     right.filename = "test-pattern-1.png";
     if (!std::filesystem::exists(right.filename)) {
-        Log::Error(std::format("Could not find image '{}'", right.filename));
+        Log::Error(sgctcompat::format("Could not find image '{}'", right.filename));
         exit(EXIT_FAILURE);
     }
     std::thread t2(loadImage, std::ref(right));
@@ -367,7 +368,7 @@ void initializeBox() {
     ImageData back;
     back.filename = "test-pattern-2.png";
     if (!std::filesystem::exists(back.filename)) {
-        Log::Error(std::format("Could not find image '{}'", back.filename));
+        Log::Error(sgctcompat::format("Could not find image '{}'", back.filename));
         exit(EXIT_FAILURE);
     }
     std::thread t3(loadImage, std::ref(back));
@@ -375,7 +376,7 @@ void initializeBox() {
     ImageData left;
     left.filename = "test-pattern-3.png";
     if (!std::filesystem::exists(left.filename)) {
-        Log::Error(std::format("Could not find image '{}'", left.filename));
+        Log::Error(sgctcompat::format("Could not find image '{}'", left.filename));
         exit(EXIT_FAILURE);
     }
     std::thread t4(loadImage, std::ref(left));
@@ -383,7 +384,7 @@ void initializeBox() {
     ImageData top;
     top.filename = "test-pattern-4.png";
     if (!std::filesystem::exists(top.filename)) {
-        Log::Error(std::format("Could not find image '{}'", top.filename));
+        Log::Error(sgctcompat::format("Could not find image '{}'", top.filename));
         exit(EXIT_FAILURE);
     }
     std::thread t5(loadImage, std::ref(top));
@@ -391,7 +392,7 @@ void initializeBox() {
     ImageData bottom;
     bottom.filename = "test-pattern-5.png";
     if (!std::filesystem::exists(bottom.filename)) {
-        Log::Error(std::format("Could not find image '{}'", bottom.filename));
+        Log::Error(sgctcompat::format("Could not find image '{}'", bottom.filename));
         exit(EXIT_FAILURE);
     }
     std::thread t6(loadImage, std::ref(bottom));
@@ -556,7 +557,7 @@ void draw2D(const RenderData& data) {
 void postDraw() {
     if (runTests) {
         frameNumber++;
-        Log::Info(std::format("Frame: {}", frameNumber));
+        Log::Info(sgctcompat::format("Frame: {}", frameNumber));
     }
 
     if (Engine::instance().isMaster() && runTests) {

--- a/apps/datatransfer/main.cpp
+++ b/apps/datatransfer/main.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <fstream>
 #include <memory>
+#include <sgct/format_compat.h>
 
 namespace {
     std::unique_ptr<std::thread> loadThread;
@@ -194,7 +195,7 @@ void uploadTexture() {
 
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Texture id {} loaded ({}x{}x{})",
         tex, transImg->size().x, transImg->size().y, transImg->channels()
     ));
@@ -362,7 +363,7 @@ void keyboard(Key key, Modifier, Action action, int, Window*) {
 }
 
 void dataTransferDecoder(void* data, int length, int packageId, int clientIndex) {
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Decoding {} bytes in transfer id: {} on node {}", length, packageId, clientIndex
     ));
 
@@ -374,13 +375,13 @@ void dataTransferDecoder(void* data, int length, int packageId, int clientIndex)
 }
 
 void dataTransferStatus(bool connected, int clientIndex) {
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Transfer node {} is {}", clientIndex, connected ? "connected" : "disconnected"
     ));
 }
 
 void dataTransferAcknowledge(int packageId, int clientIndex) {
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Transfer id: {} is completed on node {}", packageId, clientIndex
     ));
 
@@ -391,7 +392,7 @@ void dataTransferAcknowledge(int packageId, int clientIndex) {
             clientsUploadDone = true;
             counter = 0;
 
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Time to distribute and upload textures on cluster: {} ms",
                 (time() - sendTimer) * 1000.0
             ));

--- a/apps/domeimageviewer/main.cpp
+++ b/apps/domeimageviewer/main.cpp
@@ -12,6 +12,7 @@
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 #include <fstream>
+#include <sgct/format_compat.h>
 
 namespace {
     std::unique_ptr<std::thread> loadThread;
@@ -180,7 +181,7 @@ void uploadTexture() {
         // unbind
         glBindTexture(GL_TEXTURE_2D, 0);
 
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Texture id %d loaded ({}x{}x{})",
             tex, transImages[i]->size().x, transImages[i]->size().y,
             transImages[i]->channels()
@@ -377,7 +378,7 @@ void keyboard(Key key, Modifier, Action action, int, Window*) {
 void dataTransferDecoder(void* receivedData, int receivedLength, int packageId,
                          int clientIndex)
 {
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Decoding {} bytes in transfer id: {} on node {}",
         receivedLength, packageId, clientIndex
     ));
@@ -390,13 +391,13 @@ void dataTransferDecoder(void* receivedData, int receivedLength, int packageId,
 }
 
 void dataTransferStatus(bool connected, int clientIndex) {
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Transfer node {} is {}", clientIndex, connected ? "connected" : "disconnected"
     ));
 }
 
 void dataTransferAcknowledge(int packageId, int clientIndex) {
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Transfer id: {} is completed on node {}", packageId, clientIndex
     ));
 
@@ -407,7 +408,7 @@ void dataTransferAcknowledge(int packageId, int clientIndex) {
             clientsUploadDone = true;
             counter = 0;
 
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Time to distribute and upload textures on cluster: {} ms",
                 (time() - sendTimer) * 1000.0
             ));

--- a/apps/gamepad/main.cpp
+++ b/apps/gamepad/main.cpp
@@ -10,6 +10,7 @@
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
+#include <sgct/format_compat.h>
 
 namespace {
     const char* joyStick1Name = nullptr;
@@ -78,7 +79,7 @@ int main(int argc, char** argv) {
 
     joyStick1Name = glfwGetJoystickName(static_cast<int>(Joystick::Joystick1));
     if (joyStick1Name) {
-        Log::Info(std::format("Joystick 1 '{}' is present", joyStick1Name));
+        Log::Info(sgctcompat::format("Joystick 1 '{}' is present", joyStick1Name));
 
         int numberOfAxes = 0;
         glfwGetJoystickAxes(static_cast<int>(Joystick::Joystick1), &numberOfAxes);
@@ -86,7 +87,7 @@ int main(int argc, char** argv) {
         int numberOfButtons = 0;
         glfwGetJoystickButtons(static_cast<int>(Joystick::Joystick1), &numberOfButtons);
 
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Number of axes {}\nNumber of buttons {}", numberOfAxes, numberOfButtons
         ));
     }

--- a/apps/network/main.cpp
+++ b/apps/network/main.cpp
@@ -11,6 +11,7 @@
 #include <sgct/opengl.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
+#include <sgct/format_compat.h>
 
 namespace {
     std::unique_ptr<std::thread> connectionThread;
@@ -69,25 +70,25 @@ void networkConnectionUpdated(Network& conn) {
 
     connected = conn.isConnected();
 
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Network is {}", conn.isConnected() ? "connected" : "disconneced"
     ));
 }
 
 void networkAck(int packageId, int) {
-    Log::Info(std::format("Network package {} is received", packageId));
+    Log::Info(sgctcompat::format("Network package {} is received", packageId));
 
     if (timerData.second == packageId) {
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Loop time: {} ms", (time() - timerData.first) * 1000.0
         ));
     }
 }
 
 void networkDecode(void* receivedData, int receivedLength, int packageId, int) {
-    Log::Info(std::format("Network decoding package {}", packageId));
+    Log::Info(sgctcompat::format("Network decoding package {}", packageId));
     std::string test(reinterpret_cast<char*>(receivedData), receivedLength);
-    Log::Info(std::format("Message: \"{}\"", test));
+    Log::Info(sgctcompat::format("Message: \"{}\"", test));
 }
 
 void connect() {
@@ -110,7 +111,7 @@ void connect() {
 
     // init
     try {
-        Log::Debug(std::format("Initiating network connection at port {}", port));
+        Log::Debug(sgctcompat::format("Initiating network connection at port {}", port));
 
         networkPtr->setUpdateFunction(networkConnectionUpdated);
         networkPtr->setPackageDecodeFunction(networkDecode);
@@ -118,7 +119,7 @@ void connect() {
         networkPtr->initialize();
     }
     catch (const std::runtime_error& err) {
-        Log::Error(std::format("Network error: {}", err.what()));
+        Log::Error(sgctcompat::format("Network error: {}", err.what()));
         networkPtr->initShutdown();
         std::this_thread::sleep_for(std::chrono::seconds(1));
         networkPtr->closeNetwork(true);
@@ -278,11 +279,11 @@ int main(int argc, char** argv) {
         std::string_view v(argv[i]);
         if (v == "-port" && argc > (i + 1)) {
             port = std::stoi(argv[i + 1]);
-            Log::Info(std::format("Setting port to: {}", port));
+            Log::Info(sgctcompat::format("Setting port to: {}", port));
         }
         else if (v == "-address" && argc > (i + 1)) {
             address = argv[i + 1];
-            Log::Info(std::format("Setting address to: {}", address));
+            Log::Info(sgctcompat::format("Setting address to: {}", address));
         }
         else if (v == "--server") {
             isServer = true;

--- a/apps/omnistereo/main.cpp
+++ b/apps/omnistereo/main.cpp
@@ -14,6 +14,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
+#include <sgct/format_compat.h>
 
 namespace {
     constexpr float Diameter = 14.8f;
@@ -156,7 +157,7 @@ void initOmniStereo(bool mask) {
         win.framebufferResolution().y / tileSize
     };
 
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Allocating: {} MB data", (sizeof(OmniData) * res.x * res.y) / (1024 * 1024)
     ));
     omniProjections.resize(res.x);
@@ -339,7 +340,7 @@ void initOmniStereo(bool mask) {
     }
 
     int percentage = (100 * VPCounter) / (res.x * res.y * 3);
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Time to init viewports: {} s\n{} %% will be rendered",
         time() - t0, percentage
     ));
@@ -410,7 +411,7 @@ void drawOmniStereo(const RenderData& renderData) {
         }
     }
 
-    Log::Info(std::format("Time to draw frame: {}s", time() - t0));
+    Log::Info(sgctcompat::format("Time to draw frame: {}s", time() - t0));
 }
 
 void draw(const RenderData& data) {
@@ -542,11 +543,11 @@ int main(int argc, char** argv) {
 
         if (argument == "-turnmap" && argc > i + 1) {
             turnMapSrc = argv[i + 1];
-            Log::Info(std::format("Setting turn map path to {}", turnMapSrc));
+            Log::Info(sgctcompat::format("Setting turn map path to {}", turnMapSrc));
         }
         if (argument == "-sepmap" && argc > i + 1) {
             sepMapSrc = argv[i + 1];
-            Log::Info(std::format("Setting separation map path to '{}'", sepMapSrc));
+            Log::Info(sgctcompat::format("Setting separation map path to '{}'", sepMapSrc));
         }
     }
 

--- a/apps/spout/main.cpp
+++ b/apps/spout/main.cpp
@@ -24,6 +24,7 @@
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
+#include <sgct/format_compat.h>
 
 
 namespace {
@@ -79,7 +80,7 @@ using namespace sgct;
 bool bindSpout() {
     const bool creationSuccess = receiver->CreateReceiver(senderName, width, height);
     if (!initialized && creationSuccess) {
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Spout: Initing {}x{} texture from '{}'", width, height, senderName
         ));
         initialized = true;

--- a/apps/spoutbrowser/main.cpp
+++ b/apps/spoutbrowser/main.cpp
@@ -24,6 +24,7 @@
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
+#include <sgct/format_compat.h>
 
 namespace {
     GLuint vao = 0;
@@ -97,7 +98,7 @@ bool bindSpout() {
     }
     const bool creationSuccess = receiver->CreateReceiver(name.data(), width, height);
     if (!isInitialized && creationSuccess) {
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Spout: Initializing {}x{} texture from '{}'", width, height, name.data()
         ));
         isInitialized = true;
@@ -192,12 +193,12 @@ void draw2D(const RenderData& data) {
         const Sender& sender = senders[i];
         std::string text;
         if (i == currentSender) {
-            text = std::format(
+            text = sgctcompat::format(
                 FormatSelected, i, sender.name, sender.width, sender.height
             );
         }
         else {
-            text = std::format(
+            text = sgctcompat::format(
                 Format, i, sender.name, sender.width, sender.height
             );
         }

--- a/apps/spoutscreenshot/main.cpp
+++ b/apps/spoutscreenshot/main.cpp
@@ -17,6 +17,7 @@
 #define NOMINMAX
 #endif
 #include <SpoutLibrary.h>
+#include <sgct/format_compat.h>
 
 namespace {
     struct {
@@ -59,7 +60,7 @@ using namespace sgct;
 bool bindSpout() {
     const bool creationSuccess = receiver->CreateReceiver(sender.data(), width, height);
     if (!initialized && creationSuccess) {
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Spout: Initing {}x{} texture from '{}'", width, height, sender
         ));
         initialized = true;

--- a/apps/stitcher/main.cpp
+++ b/apps/stitcher/main.cpp
@@ -13,6 +13,7 @@
 #include <sgct/user.h>
 #include <cstring>
 #include <format>
+#include <sgct/format_compat.h>
 
 namespace {
     enum class Rotation { Deg0 = 0, Deg90, Deg180, Deg270 };
@@ -467,14 +468,14 @@ int main(int argc, char** argv) {
             texturePaths[static_cast<int>(getSideIndex(numberOfTextures))] = tmpStr;
 
             numberOfTextures++;
-            Log::Info(std::format("Adding texture: {}", argv[i + 1]));
+            Log::Info(sgctcompat::format("Adding texture: {}", argv[i + 1]));
         }
         else if (arg == "-seq" && argc > (i + 2)) {
             sequence = true;
             int startIndex = atoi(argv[i + 1]);
             stopIndex = atoi(argv[i + 2]);
             iterator = startIndex;
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Loading sequence from {} to {}", startIndex, stopIndex
             ));
         }
@@ -485,7 +486,7 @@ int main(int argc, char** argv) {
                 atoi(argv[i + 3]),
                 atoi(argv[i + 4])
             };
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Setting image rotations to L: {}, R: {}, T: {}, B: {}",
                 rotations.x, rotations.y, rotations.z, rotations.w
             ));
@@ -510,59 +511,59 @@ int main(int argc, char** argv) {
         }
         else if (arg == "-start" && argc > (i + 1)) {
             startFrame = atoi(argv[i + 1]);
-            Log::Info(std::format("Start frame set to {}", startFrame));
+            Log::Info(sgctcompat::format("Start frame set to {}", startFrame));
         }
         else if (arg == "-alpha" && argc > (i + 1)) {
             settings.alpha = std::string_view(argv[i + 1]) == "1";
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Setting alpha to {}", settings.alpha ? "true" : "false"
             ));
         }
         else if (arg == "-stereo" && argc > (i + 1)) {
             settings.stereo = std::string_view(argv[i + 1]) == "1";
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Setting stereo to {}", settings.stereo ? "true" : "false"
             ));
         }
         else if (arg == "-cubic" && argc > (i + 1)) {
             settings.cubic = std::string_view(argv[i + 1]) == "1";
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Setting cubic interpolation to {}", settings.cubic ? "true" : "false"
             ));
         }
         else if (arg == "-fxaa" && argc > (i + 1)) {
             settings.fxaa = std::string_view(argv[i + 1]) == "1";
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Setting fxaa to {}", settings.fxaa ? "true" : "false"
             ));
         }
         else if (arg == "-eyeSep" && argc > (i + 1)) {
             settings.eyeSeparation = static_cast<float>(atof(argv[i + 1]));
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Setting eye separation to {}", settings.eyeSeparation
             ));
         }
         else if (arg == "-diameter" && argc > (i + 1)) {
             settings.domeDiameter = static_cast<float>(atof(argv[i + 1]));
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Setting dome diameter to {}", settings.domeDiameter
             ));
         }
         else if (arg == "-msaa" && argc > (i + 1)) {
             settings.numberOfMSAASamples = atoi(argv[i + 1]);
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Number of MSAA samples set to {}", settings.numberOfMSAASamples
             ));
         }
         else if (arg == "-res" && argc > (i + 1)) {
             settings.resolution = atoi(argv[i + 1]);
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Resolution set to {}", settings.resolution
             ));
         }
         else if (arg == "-cubemap" && argc > (i + 1)) {
             settings.cubemapRes = atoi(argv[i + 1]);
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Cubemap resolution set to {}", settings.cubemapRes
             ));
         }
@@ -584,11 +585,11 @@ int main(int argc, char** argv) {
                 }
             } (arg2);
             Settings::instance().setCaptureFormat(f);
-            Log::Info(std::format("Format set to {}", argv[i + 1]));
+            Log::Info(sgctcompat::format("Format set to {}", argv[i + 1]));
         }
         else if (arg == "-path" && argc > (i + 1)) {
             Settings::instance().setCapturePath(argv[i + 1]);
-            Log::Info(std::format("Left path set to {}", argv[i + 1]));
+            Log::Info(sgctcompat::format("Left path set to {}", argv[i + 1]));
         }
         else if (arg == "-leftPath" || arg == "-rightPath") {
             Log::Warning("-leftPath and -rightPath are no longer supported; use -path");

--- a/include/sgct/format.h
+++ b/include/sgct/format.h
@@ -10,17 +10,34 @@
 #define __SGCT__FMT__H__
 
 #include <filesystem>
-#include <format>
+// Prefer sgct::format if available, otherwise use the fmt library for Mac
+#ifndef __clang__
+    #include <format>
+    // If you need a formatter for std::filesystem::path in sgct::format, you can add it here if not provided by your standard library.
 
-template <>
-struct std::formatter<std::filesystem::path> {
-    constexpr auto parse(std::format_parse_context& ctx) {
-        return ctx.begin();
-    }
+    template <>
+    struct std::formatter<std::filesystem::path> {
+        constexpr auto parse(std::format_parse_context& ctx) {
+            return ctx.begin();
+        }
 
-    auto format(const std::filesystem::path& path, std::format_context& ctx) const {
-        return std::format_to(ctx.out(), "{}", path.string());
-    }
-};
+        auto format(const std::filesystem::path& path, std::format_context& ctx) const {
+            return std::format_to(ctx.out(), "{}", path.string());
+        }
+    };
+#else
+    #include <fmt/format.h>
+
+    template <>
+    struct fmt::formatter<std::filesystem::path> {
+        constexpr auto parse(fmt::format_parse_context& ctx) {
+            return ctx.begin();
+        }
+
+        auto format(const std::filesystem::path& path, fmt::format_context& ctx) const {
+            return fmt::format_to(ctx.out(), "{}", path.string());
+        }
+    };
+#endif // ifndef __clang__
 
 #endif // __SGCT__FMT__H__

--- a/include/sgct/format_compat.h
+++ b/include/sgct/format_compat.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#if defined(__APPLE__)
+// On MacOS, assume std::format is not supported, use fmt::format
+#include <fmt/format.h>
+namespace sgctcompat {
+    using fmt::format;
+    using fmt::format_to_n;
+}
+#elif defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+// Use std::format if available
+#include <format>
+namespace sgctcompat {
+    using std::format;
+    using std::format_to_n;
+}
+#else
+#include <fmt/format.h>
+namespace sgctcompat {
+    using fmt::format;
+    using fmt::format_to_n;
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -240,10 +240,11 @@ target_compile_definitions(sgct
 if (WIN32)
   target_link_libraries(sgct PRIVATE ws2_32)
 elseif (APPLE)
+  find_package(fmt REQUIRED)
   find_library(COCOA_LIBRARY Cocoa REQUIRED)
   find_library(IOKIT_LIBRARY IOKit REQUIRED)
   find_library(COREVIDEO_LIBRARY CoreVideo REQUIRED)
-  target_link_libraries(sgct PRIVATE ${COCOA_LIBRARY} ${IOKIT_LIBRARY} ${COREVIDEO_LIBRARY})
+  target_link_libraries(sgct PRIVATE fmt::fmt ${COCOA_LIBRARY} ${IOKIT_LIBRARY} ${COREVIDEO_LIBRARY})
 else () # Linux
   find_package(X11 REQUIRED)
   find_package(Threads REQUIRED)

--- a/src/correction/domeprojection.cpp
+++ b/src/correction/domeprojection.cpp
@@ -17,6 +17,7 @@
 #include <scn/scan.h>
 #include <algorithm>
 #include <fstream>
+#include <sgct/format_compat.h>
 
 namespace sgct::correction {
 
@@ -25,13 +26,13 @@ Buffer generateDomeProjectionMesh(const std::filesystem::path& path, const vec2&
 {
     ZoneScoped;
 
-    Log::Info(std::format("Reading DomeProjection mesh data from '{}'", path));
+    Log::Info(sgctcompat::format("Reading DomeProjection mesh data from '{}'", path));
 
     std::ifstream meshFile = std::ifstream(path);
     if (!meshFile.good()) {
         throw Error(
             Error::Component::DomeProjection, 2010,
-            std::format("Failed to open '{}'", path)
+            sgctcompat::format("Failed to open '{}'", path)
         );
     }
 

--- a/src/correction/obj.cpp
+++ b/src/correction/obj.cpp
@@ -15,6 +15,7 @@
 #include <sgct/profiling.h>
 #include <cassert>
 #include <fstream>
+#include <sgct/format_compat.h>
 
 namespace {
     struct Position {
@@ -37,12 +38,12 @@ namespace sgct::correction {
 Buffer generateOBJMesh(const std::filesystem::path& path) {
     ZoneScoped;
 
-    Log::Info(std::format("Reading Wavefront OBJ mesh data from '{}'", path));
+    Log::Info(sgctcompat::format("Reading Wavefront OBJ mesh data from '{}'", path));
 
     std::ifstream file = std::ifstream(path);
     if (!file.good()) {
         throw Error(
-            Error::Component::OBJ, 2030, std::format("Failed to open '{}'", path)
+            Error::Component::OBJ, 2030, sgctcompat::format("Failed to open '{}'", path)
         );
     }
 
@@ -71,7 +72,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::OBJ, 2034,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal vertex format in OBJ file '{}' in line {}", path, line
                     )
                 );
@@ -83,7 +84,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::OBJ, 2034,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal vertex format in OBJ file '{}' in line {}", path, line
                     )
                 );
@@ -94,7 +95,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
             const std::string_view v3 = rest;
             const float z = std::stof(std::string(v3));
             if (z != 0.f) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Vertex in '{}' was using z coordinate which is not supported", path
                 ));
             }
@@ -122,7 +123,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::OBJ, 2035,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal face format in OBJ file '{}' in line {}", path, line
                     )
                 );
@@ -134,7 +135,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::OBJ, 2035,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal face format in OBJ file '{}' in line {}", path, line
                     )
                 );
@@ -159,34 +160,34 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
         }
         else if (first == "vn") {
             if (std::find(reported.begin(), reported.end(), "vn") == reported.end()) {
-                Log::Warning(std::format("Ignoring normals in mesh '{}'", path));
+                Log::Warning(sgctcompat::format("Ignoring normals in mesh '{}'", path));
                 reported.emplace_back("vn");
             }
         }
         else if (first == "vp") {
             if (std::find(reported.begin(), reported.end(), "vp") == reported.end()) {
                 Log::Warning(
-                    std::format("Ignoring parameter space values in mesh '{}'", path)
+                    sgctcompat::format("Ignoring parameter space values in mesh '{}'", path)
                 );
                 reported.emplace_back("vp");
             }
         }
         else if (first == "l") {
             if (std::find(reported.begin(), reported.end(), "l") == reported.end()) {
-                Log::Warning(std::format("Ignoring line elements in mesh '{}'", path));
+                Log::Warning(sgctcompat::format("Ignoring line elements in mesh '{}'", path));
                 reported.emplace_back("l");
             }
         }
         else if (first == "mtllib") {
             if (std::find(reported.begin(), reported.end(), "mtllib") == reported.end()) {
-                Log::Warning(std::format("Ignoring material library in mesh '{}'", path));
+                Log::Warning(sgctcompat::format("Ignoring material library in mesh '{}'", path));
                 reported.emplace_back("mtllib");
             }
         }
         else if (first == "usemtl") {
             if (std::find(reported.begin(), reported.end(), "usemtl") == reported.end()) {
                 Log::Warning(
-                    std::format("Ignoring material specification in mesh '{}'", path)
+                    sgctcompat::format("Ignoring material specification in mesh '{}'", path)
                 );
                 reported.emplace_back("usemtl");
             }
@@ -194,7 +195,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
         else if (first == "o") {
             if (std::find(reported.begin(), reported.end(), "o") == reported.end()) {
                 Log::Warning(
-                    std::format("Ignoring object specification in mesh '{}'", path)
+                    sgctcompat::format("Ignoring object specification in mesh '{}'", path)
                 );
                 reported.emplace_back("o");
             }
@@ -202,7 +203,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
         else if (first == "g") {
             if (std::find(reported.begin(), reported.end(), "g") == reported.end()) {
                 Log::Warning(
-                    std::format("Ignoring object group specification in mesh '{}'", path)
+                    sgctcompat::format("Ignoring object group specification in mesh '{}'", path)
                 );
                 reported.emplace_back("g");
             }
@@ -210,14 +211,14 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
         else if (first == "s") {
             if (std::find(reported.begin(), reported.end(), "s") == reported.end()) {
                 Log::Warning(
-                    std::format("Ignoring shading specification in mesh '{}'", path)
+                    sgctcompat::format("Ignoring shading specification in mesh '{}'", path)
                 );
                 reported.emplace_back("s");
             }
         }
         else {
             if (std::find(reported.begin(), reported.end(), first) == reported.end()) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Encounted unsupported value type '{}' in mesh '{}'", first, path
                 ));
                 reported.emplace_back(first);
@@ -228,7 +229,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
     if (positions.size() != texCoords.size()) {
         throw Error(
             Error::Component::OBJ, 2031,
-            std::format(
+            sgctcompat::format(
                 "Vertex count doesn't match number of texture coordinates in '{}'", path
             )
         );
@@ -241,7 +242,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
         if (invalid) {
             throw Error(
                 Error::Component::OBJ, 2032,
-                std::format(
+                sgctcompat::format(
                     "Faces in mesh '{}' referenced vertices that were undefined", path
                 )
             );
@@ -250,7 +251,7 @@ Buffer generateOBJMesh(const std::filesystem::path& path) {
         if (f.f1 < 0 || f.f2 < 0 || f.f3 < 0) {
             throw Error(
                 Error::Component::OBJ, 2033,
-                std::format(
+                sgctcompat::format(
                     "Faces in mesh '{}' are using relative index positions that are "
                     "unsupported", path
                 )

--- a/src/correction/paulbourke.cpp
+++ b/src/correction/paulbourke.cpp
@@ -18,6 +18,7 @@
 #include <glm/glm.hpp>
 #include <scn/scan.h>
 #include <fstream>
+#include <sgct/format_compat.h>
 
 namespace sgct::correction {
 
@@ -28,13 +29,13 @@ Buffer generatePaulBourkeMesh(const std::filesystem::path& path, const vec2& pos
 
     Buffer buf;
 
-    Log::Info(std::format("Reading Paul Bourke spherical mirror mesh from '{}'", path));
+    Log::Info(sgctcompat::format("Reading Paul Bourke spherical mirror mesh from '{}'", path));
 
     std::ifstream meshFile = std::ifstream(path);
     if (!meshFile.good()) {
         throw Error(
             Error::Component::PaulBourke, 2040,
-            std::format("Failed to open '{}'", path)
+            sgctcompat::format("Failed to open '{}'", path)
         );
     }
 
@@ -46,7 +47,7 @@ Buffer generatePaulBourkeMesh(const std::filesystem::path& path, const vec2& pos
         if (!r) {
             throw Error(
                 Error::Component::PaulBourke, 2041,
-                std::format("Error reading mapping type in file '{}'", path)
+                sgctcompat::format("Error reading mapping type in file '{}'", path)
             );
         }
     }
@@ -58,7 +59,7 @@ Buffer generatePaulBourkeMesh(const std::filesystem::path& path, const vec2& pos
         if (!r) {
             throw Error(
                 Error::Component::PaulBourke, 2042,
-                std::format("Invalid data in file '{}'", path)
+                sgctcompat::format("Invalid data in file '{}'", path)
             );
         }
         const auto& [valX, valY] = r->values();

--- a/src/correction/pfm.cpp
+++ b/src/correction/pfm.cpp
@@ -16,6 +16,7 @@
 #include <glm/glm.hpp>
 #include <scn/scan.h>
 #include <fstream>
+#include <sgct/format_compat.h>
 
 namespace sgct::correction {
 
@@ -26,14 +27,14 @@ Buffer generatePerEyeMeshFromPFMImage(const std::filesystem::path& path, const v
 
     Buffer buf;
 
-    Log::Info(std::format("Reading 3D/stereo mesh data (in PFM image) from '{}'", path));
+    Log::Info(sgctcompat::format("Reading 3D/stereo mesh data (in PFM image) from '{}'", path));
 
     std::ifstream meshFile = std::ifstream(path, std::ifstream::binary);
     if (!meshFile.good()) {
         throw Error(
             Error::Component::Pfm,
             2050,
-            std::format("Failed to open '{}'", path)
+            sgctcompat::format("Failed to open '{}'", path)
         );
     }
 
@@ -49,7 +50,7 @@ Buffer generatePerEyeMeshFromPFMImage(const std::filesystem::path& path, const v
     if (!result) {
         throw Error(
             Error::Component::Pfm, 2052,
-            std::format("Invalid header syntax in file '{}'", path)
+            sgctcompat::format("Invalid header syntax in file '{}'", path)
         );
     }
     auto [nCols, nRows] = result->values();
@@ -57,13 +58,13 @@ Buffer generatePerEyeMeshFromPFMImage(const std::filesystem::path& path, const v
     if (!result2) {
         throw Error(
             Error::Component::Pfm, 2052,
-            std::format("Invalid endianness value in file '{}'", path)
+            sgctcompat::format("Invalid endianness value in file '{}'", path)
         );
     }
     if (fileFormatHeader[0] != 'P' || fileFormatHeader[1] != 'F') {
         throw Error(
             Error::Component::Pfm, 2053,
-            std::format("Incorrect file type in file '{}'", path)
+            sgctcompat::format("Incorrect file type in file '{}'", path)
         );
     }
 
@@ -82,7 +83,7 @@ Buffer generatePerEyeMeshFromPFMImage(const std::filesystem::path& path, const v
         if (!meshFile.good()) {
             throw Error(
                 Error::Component::Pfm, 2054,
-                std::format("Error reading correction values in file '{}'", path)
+                sgctcompat::format("Error reading correction values in file '{}'", path)
             );
         }
     }

--- a/src/correction/scalable.cpp
+++ b/src/correction/scalable.cpp
@@ -20,6 +20,7 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <fstream>
+#include <sgct/format_compat.h>
 
 namespace {
     struct Data {
@@ -99,12 +100,12 @@ namespace sgct::correction {
 Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& parent) {
     ZoneScoped;
 
-    Log::Info(std::format("Reading scalable mesh data from '{}'", path));
+    Log::Info(sgctcompat::format("Reading scalable mesh data from '{}'", path));
 
     std::ifstream file = std::ifstream(path);
     if (!file.good()) {
         throw Error(
-            Error::Component::Scalable, 2060, std::format("Failed to open '{}'", path)
+            Error::Component::Scalable, 2060, sgctcompat::format("Failed to open '{}'", path)
         );
     }
 
@@ -125,7 +126,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
 
         if (first == "OPENMESH") {
             if (rest != "Version 1.1") {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Found {} in mesh '{}' but expected Version 1.1 so the loading might "
                     "misbehave", rest, path
                 ));
@@ -141,7 +142,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         }
         else if (first == "MAPPING") {
             if (rest != "NORMALIZED") {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Found mapping '{}' in mesh '{}' but only 'NORMALIZED' is supported",
                     rest, path
                 ));
@@ -149,7 +150,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         }
         else if (first == "SAMPLING") {
             if (rest != "LINEAR") {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Found sampling '{}' in mesh '{}' but only 'LINEAR' is supported",
                     rest, path
                 ));
@@ -157,7 +158,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         }
         else if (first == "PROJECTION") {
             if (rest != "PERSPECTIVE") {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Found projection '{}' in mesh '{}' but only 'PERSPECTIVE' is "
                     "supported", rest, path
                 ));
@@ -221,7 +222,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         else if (first == "SUBVERSION") {
             const int version = std::stoi(std::string(rest));
             if (version != 5) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Found subversion {} in mesh '{}' but only version 5 is tested",
                     version, path
                 ));
@@ -231,7 +232,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             const float gamma = std::stof(std::string(rest));
             if (gamma != data.gamma) {
                 data.gamma = gamma;
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Found GAMMA value of {} in mesh '{}' we do not support per-viewport "
                     "gamma values", data.gamma, path
                 ));
@@ -243,7 +244,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         else if (first == "USE_SPHERE_SAMPLE_COORDINATE_SYSTEM") {
             const bool useSphereSampling = std::stoi(std::string(rest)) != 0;
             if (useSphereSampling) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Found request to use Sphere Sample Coordinate System in mesh {} "
                     "but we do not support this", path
                 ));
@@ -252,7 +253,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         else if (first == "FRUSTUM_EULER_ANGLES") {
             data.frustumEulerAngles.useAngles = std::stoi(std::string(rest)) != 0;
             if (data.frustumEulerAngles.useAngles) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Enabled frustum euler angles in mesh '{}' but we do not know how "
                     "these work, yet", path
                 ));
@@ -273,7 +274,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         else if (first == "APPLY_MASK") {
             data.applyMask = std::stoi(std::string(rest)) != 0;
             if (data.applyMask) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Mesh '{}' requested to apply a mask. Currently this is handled "
                     "outside the mesh by specifying a 'mask' attribute on the 'Viewport' "
                     "instead", path
@@ -283,7 +284,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         else if (first == "APPLY_BLACK_LEVEL") {
             data.applyBlackLevel = std::stoi(std::string(rest)) != 0;
             if (data.applyBlackLevel) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Mesh '{}' requested to apply a blacklevel image. Currently this is "
                     "handled outside the mesh by specifying a 'BlackLevelMask' attribute "
                     "on the 'Viewport' instead", path
@@ -293,7 +294,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
         else if (first == "APPLY_COLOR") {
             data.applyColor = std::stoi(std::string(rest)) != 0;
             if (data.applyBlackLevel) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Mesh '{}' requested to apply an overlay image. Currently this is "
                     "handled outside the mesh by specifying an 'overlay' attribute on "
                     "the 'Viewport' instead", path
@@ -306,7 +307,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::Scalable, 2035,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal formatting of face in file '{}' in line {}",
                         path, line
                     )
@@ -319,7 +320,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::Scalable, 2035,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal formatting of face in file '{}' in line {}",
                         path, line
                     )
@@ -332,7 +333,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::Scalable, 2035,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal formatting of face in file '{}' in line {}",
                         path, line
                     )
@@ -354,7 +355,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
                 [[maybe_unused]] const float dummy = std::stof(std::string(first));
             }
             catch (const std::invalid_argument&) {
-                Log::Warning(std::format(
+                Log::Warning(sgctcompat::format(
                     "Unknown key {} found in scalable mesh '{}'. Please report usage of "
                     "this key, preferably with an example, to the SGCT developers",
                     first, path
@@ -369,7 +370,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::Scalable, 2036,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal formatting of vertex in file '{}' in line {}",
                         path, line
                     )
@@ -382,7 +383,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::Scalable, 2036,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal formatting of vertex in file '{}' in line {}",
                         path, line
                     )
@@ -395,7 +396,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::Scalable, 2036,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal formatting of vertex in file '{}' in line {}",
                         path, line
                     )
@@ -407,7 +408,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
             if (sep == std::string_view::npos) {
                 throw Error(
                     Error::Component::Scalable, 2036,
-                    std::format(
+                    sgctcompat::format(
                         "Illegal formatting of vertex in file '{}' in line {}",
                         path, line
                     )
@@ -458,7 +459,7 @@ Buffer generateScalableMesh(const std::filesystem::path& path, BaseViewport& par
     {
         throw Error(
             Error::Component::Scalable, 2061,
-            std::format("Incorrect mesh data geometry in file '{}'", path)
+            sgctcompat::format("Incorrect mesh data geometry in file '{}'", path)
         );
     }
 

--- a/src/correction/sciss.cpp
+++ b/src/correction/sciss.cpp
@@ -20,6 +20,7 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/euler_angles.hpp>
 #include <fstream>
+#include <sgct/format_compat.h>
 
 #define Error(code, msg) sgct::Error(sgct::Error::Component::SCISS, code, msg)
 
@@ -59,12 +60,12 @@ Buffer generateScissMesh(const std::filesystem::path& path, BaseViewport& parent
 
     Buffer buf;
 
-    Log::Info(std::format("Reading SCISS mesh data from '{}'", path));
+    Log::Info(sgctcompat::format("Reading SCISS mesh data from '{}'", path));
 
     
     std::ifstream file = std::ifstream(path, std::ifstream::binary);
     if (!file.good()) {
-        throw Error(2070, std::format("Failed to open '{}'", path));
+        throw Error(2070, sgctcompat::format("Failed to open '{}'", path));
     }
 
     char fileID[3];
@@ -72,26 +73,26 @@ Buffer generateScissMesh(const std::filesystem::path& path, BaseViewport& parent
 
     // check fileID
     if (!file.good() || fileID[0] != 'S' || fileID[1] != 'G' || fileID[2] != 'C') {
-        throw Error(2071, std::format("Incorrect file id in file '{}'", path));
+        throw Error(2071, sgctcompat::format("Incorrect file id in file '{}'", path));
     }
 
     // read file version
     uint8_t fileVersion = 0;
     file.read(reinterpret_cast<char*>(&fileVersion), sizeof(uint8_t));
     if (!file.good()) {
-        throw Error(2072, std::format("Error parsing file version from file '{}'", path));
+        throw Error(2072, sgctcompat::format("Error parsing file version from file '{}'", path));
     }
 
-    Log::Debug(std::format("SCISS file version '{}'", fileVersion));
+    Log::Debug(sgctcompat::format("SCISS file version '{}'", fileVersion));
 
     // read mapping type
     unsigned int type = 0;
     file.read(reinterpret_cast<char*>(&type), sizeof(unsigned int));
     if (!file.good()) {
-        throw Error(2073, std::format("Error parsing type from file '{}'", path));
+        throw Error(2073, sgctcompat::format("Error parsing type from file '{}'", path));
     }
 
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "Mapping type: {} ({})", type == 0 ? "planar" : "cube", type)
     );
 
@@ -99,7 +100,7 @@ Buffer generateScissMesh(const std::filesystem::path& path, BaseViewport& parent
     SCISSViewData viewData;
     file.read(reinterpret_cast<char*>(&viewData), sizeof(SCISSViewData));
     if (!file.good()) {
-        throw Error(2074, std::format("Error parsing view data from file '{}'", path));
+        throw Error(2074, sgctcompat::format("Error parsing view data from file '{}'", path));
     }
 
     const double x = static_cast<double>(viewData.qx);
@@ -114,14 +115,14 @@ Buffer generateScissMesh(const std::filesystem::path& path, BaseViewport& parent
     const double pitch = angles.y;
     const double roll = -angles.z;
 
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "Rotation quat = [{} {} {} {}]. yaw = {}, pitch = {}, roll = {}",
         viewData.qx, viewData.qy, viewData.qz, viewData.qw, yaw, pitch, roll)
     );
 
-    Log::Debug(std::format("Position: {} {} {}", viewData.x, viewData.y, viewData.z));
+    Log::Debug(sgctcompat::format("Position: {} {} {}", viewData.x, viewData.y, viewData.z));
 
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "FOV: (up {}) (down {}) (left {}) (right {})",
         viewData.fovUp, viewData.fovDown, viewData.fovLeft, viewData.fovRight
     ));
@@ -130,17 +131,17 @@ Buffer generateScissMesh(const std::filesystem::path& path, BaseViewport& parent
     unsigned int size[2];
     file.read(reinterpret_cast<char*>(size), 2 * sizeof(unsigned int));
     if (!file.good()) {
-        throw Error(2075, std::format("Error parsing file '{}'", path));
+        throw Error(2075, sgctcompat::format("Error parsing file '{}'", path));
     }
 
     unsigned int nVertices = 0;
     if (fileVersion == 2) {
         nVertices = size[1];
-        Log::Debug(std::format("Number of vertices: {}", nVertices));
+        Log::Debug(sgctcompat::format("Number of vertices: {}", nVertices));
     }
     else {
         nVertices = size[0] * size[1];
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "Number of vertices: {} ({}x{})", nVertices, size[0], size[1]
         ));
     }
@@ -151,16 +152,16 @@ Buffer generateScissMesh(const std::filesystem::path& path, BaseViewport& parent
         nVertices * sizeof(SCISSTexturedVertex)
     );
     if (!file.good()) {
-        throw Error(2076, std::format("Error parsing vertices from file '{}'", path));
+        throw Error(2076, sgctcompat::format("Error parsing vertices from file '{}'", path));
     }
 
     // read number of indices
     unsigned int nIndices = 0;
     file.read(reinterpret_cast<char*>(&nIndices), sizeof(unsigned int));
     if (!file.good()) {
-        throw Error(2077, std::format("Error parsing indices from file '{}'", path));
+        throw Error(2077, sgctcompat::format("Error parsing indices from file '{}'", path));
     }
-    Log::Debug(std::format("Number of indices: {}", nIndices));
+    Log::Debug(sgctcompat::format("Number of indices: {}", nIndices));
 
     // read faces
     if (nIndices > 0) {
@@ -170,7 +171,7 @@ Buffer generateScissMesh(const std::filesystem::path& path, BaseViewport& parent
             nIndices * sizeof(unsigned int)
         );
         if (!file.good()) {
-            throw Error(2078, std::format("Error parsing faces from file '{}'", path));
+            throw Error(2078, sgctcompat::format("Error parsing faces from file '{}'", path));
         }
     }
 

--- a/src/correction/simcad.cpp
+++ b/src/correction/simcad.cpp
@@ -17,6 +17,7 @@
 #include <sgct/viewport.h>
 #include <glm/glm.hpp>
 #include <sstream>
+#include <sgct/format_compat.h>
 
 #define Error(code, msg) Error(Error::Component::SimCAD, code, msg)
 
@@ -45,21 +46,21 @@ Buffer generateSimCADMesh(const std::filesystem::path& path, const vec2& pos,
 
     Buffer buf;
 
-    Log::Info(std::format("Reading simcad warp data from '{}'", path));
+    Log::Info(sgctcompat::format("Reading simcad warp data from '{}'", path));
 
     tinyxml2::XMLDocument xmlDoc;
     const std::string p = path.string();
     if (xmlDoc.LoadFile(p.c_str()) != tinyxml2::XML_SUCCESS) {
         std::string s1 = xmlDoc.ErrorName() ? xmlDoc.ErrorName() : "";
         std::string s2 = xmlDoc.ErrorStr() ? xmlDoc.ErrorStr() : "";
-        throw Error(2080, std::format("Error loading file {}. {} {}", path, s1, s2));
+        throw Error(2080, sgctcompat::format("Error loading file {}. {} {}", path, s1, s2));
     }
 
     tinyxml2::XMLElement* XMLroot = xmlDoc.FirstChildElement("GeometryFile");
     if (XMLroot == nullptr) {
         throw Error(
             2081,
-            std::format("Error reading file '{}'. Missing 'GeometryFile'", path)
+            sgctcompat::format("Error reading file '{}'. Missing 'GeometryFile'", path)
         );
     }
 
@@ -68,7 +69,7 @@ Buffer generateSimCADMesh(const std::filesystem::path& path, const vec2& pos,
     if (element == nullptr) {
         throw Error(
             2082,
-            std::format("Error reading file '{}'. Missing 'GeometryDefinition'", path)
+            sgctcompat::format("Error reading file '{}'. Missing 'GeometryDefinition'", path)
         );
     }
 

--- a/src/correction/skyskan.cpp
+++ b/src/correction/skyskan.cpp
@@ -22,6 +22,7 @@
 #include <scn/scan.h>
 #include <fstream>
 #include <optional>
+#include <sgct/format_compat.h>
 
 #define Error(code, msg) sgct::Error(sgct::Error::Component::SkySkan, code, msg)
 
@@ -32,11 +33,11 @@ Buffer generateSkySkanMesh(const std::filesystem::path& path, BaseViewport& pare
 
     Buffer buf;
 
-    Log::Info(std::format("Reading SkySkan mesh data from '{}'", path));
+    Log::Info(sgctcompat::format("Reading SkySkan mesh data from '{}'", path));
 
     std::ifstream meshFile = std::ifstream(path);
     if (!meshFile.good()) {
-        throw Error(2090, std::format("Failed to open file '{}'", path));
+        throw Error(2090, sgctcompat::format("Failed to open file '{}'", path));
     }
 
     std::optional<float> azimuth;
@@ -122,7 +123,7 @@ Buffer generateSkySkanMesh(const std::filesystem::path& path, BaseViewport& pare
     if (!areDimsSet || !azimuth.has_value() || !elevation.has_value() ||
         !hFov.has_value() || *hFov <= 0.f)
     {
-        throw Error(2091, std::format("Data reading error in file '{}'", path));
+        throw Error(2091, sgctcompat::format("Data reading error in file '{}'", path));
     }
 
     // create frustums and projection matrices
@@ -133,7 +134,7 @@ Buffer generateSkySkanMesh(const std::filesystem::path& path, BaseViewport& pare
         const float hh = (1200.f / 2048.f) * hw;
         vFov = 2.f * glm::degrees<float>(std::atan(hh));
 
-        Log::Info(std::format("HFOV: {} VFOV: {}", *hFov, *vFov));
+        Log::Info(sgctcompat::format("HFOV: {} VFOV: {}", *hFov, *vFov));
     }
 
     if (fovTweaks.x > 0.f) {

--- a/src/correctionmesh.cpp
+++ b/src/correctionmesh.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
+#include <sgct/format_compat.h>
 
 #define Error(c, msg) sgct::Error(sgct::Error::Component::CorrectionMesh, c, msg)
 
@@ -254,7 +255,7 @@ void CorrectionMesh::loadMesh(const std::filesystem::path& path, BaseViewport& p
 
     _warpGeometry = CorrectionMeshGeometry(buf);
 
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "CorrectionMesh read successfully. Vertices={}, Indices={}",
         buf.vertices.size(), buf.indices.size()
     ));

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -27,6 +27,7 @@
 
 #include <array>
 #include <optional>
+#include <sgct/format_compat.h>
 
 namespace {
     struct GlyphData {
@@ -291,7 +292,7 @@ void Font::createCharacter(char c) {
         _fontFaceData[c] = std::move(*ffd);
     }
     else {
-        Log::Error(std::format("Error creating character {}", c));
+        Log::Error(sgctcompat::format("Error creating character {}", c));
     }
 }
 

--- a/src/fontmanager.cpp
+++ b/src/fontmanager.cpp
@@ -34,6 +34,7 @@
 #endif // __clang__
 
 #include <freetype/ftglyph.h>
+#include <sgct/format_compat.h>
 
 #ifdef __clang__
 #pragma clang diagnostic pop
@@ -141,7 +142,7 @@ bool FontManager::addFont(std::string name, std::string file) {
 
     const bool inserted = _fontPaths.insert({ name, std::move(file) }).second;
     if (!inserted) {
-        Log::Warning(std::format("Font with name '{}' already exists", name));
+        Log::Warning(sgctcompat::format("Font with name '{}' already exists", name));
     }
     return inserted;
 }
@@ -162,12 +163,12 @@ std::unique_ptr<Font> FontManager::createFont(const std::string& name, int heigh
     const auto it = _fontPaths.find(name);
 
     if (it == _fontPaths.end()) {
-        Log::Error(std::format("No font file specified for font '{}'", name));
+        Log::Error(sgctcompat::format("No font file specified for font '{}'", name));
         return nullptr;
     }
 
     if (_library == nullptr) {
-        Log::Error(std::format(
+        Log::Error(sgctcompat::format(
             "Freetype library is not initialized, cannot create font '{}'", name
         ));
         return nullptr;
@@ -177,19 +178,19 @@ std::unique_ptr<Font> FontManager::createFont(const std::string& name, int heigh
     const FT_Error error = FT_New_Face(_library, it->second.c_str(), 0, &face);
 
     if (error == FT_Err_Unknown_File_Format) {
-        Log::Error(std::format(
+        Log::Error(sgctcompat::format(
             "Unsupported file format '{}' for font '{}'", it->second, name
         ));
         return nullptr;
     }
     else if (error != 0 || face == nullptr) {
-        Log::Error(std::format("Font '{}' not found", it->second));
+        Log::Error(sgctcompat::format("Font '{}' not found", it->second));
         return nullptr;
     }
 
     const FT_Error charSizeErr = FT_Set_Char_Size(face, height << 6, height << 6, 96, 96);
     if (charSizeErr != 0) {
-        Log::Error(std::format("Could not set pixel size for font '{}'", name));
+        Log::Error(sgctcompat::format("Could not set pixel size for font '{}'", name));
         return nullptr;
     }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -12,6 +12,7 @@
 #include <sgct/error.h>
 #include <sgct/format.h>
 #include <sgct/log.h>
+#include <sgct/format_compat.h>
 #include <png.h>
 #include <zlib.h>
 #include <algorithm>
@@ -80,7 +81,7 @@ void Image::load(const std::filesystem::path& filename) {
     _data = stbi_load(name.c_str(), &_size.x, &_size.y, &_nChannels, 0);
     if (_data == nullptr) {
         throw Err(
-            9001, std::format("Could not open file '{}' for loading image", filename)
+            9001, sgctcompat::format("Could not open file '{}' for loading image", filename)
         );
     }
     _bytesPerChannel = 1;
@@ -120,7 +121,7 @@ void Image::save(const std::filesystem::path& filename) {
     }
 
     if (_bytesPerChannel > 2) {
-        throw Err(9007, std::format("Cannot save {} bit", _bytesPerChannel * 8));
+        throw Err(9007, sgctcompat::format("Cannot save {} bit", _bytesPerChannel * 8));
     }
 
     const double t0 = time();
@@ -128,7 +129,7 @@ void Image::save(const std::filesystem::path& filename) {
     std::string f = filename.string();
     FILE* fp = fopen(f.c_str(), "wb");
     if (fp == nullptr) {
-        throw Err(9008, std::format("Cannot create PNG file '{}'", filename));
+        throw Err(9008, sgctcompat::format("Cannot create PNG file '{}'", filename));
     }
 
     // initialize stuff
@@ -213,7 +214,7 @@ void Image::save(const std::filesystem::path& filename) {
     fclose(fp);
 
     const double t = (time() - t0) * 1000.0;
-    Log::Debug(std::format("'{}' was saved successfully ({:.2f} ms)", filename, t));
+    Log::Debug(sgctcompat::format("'{}' was saved successfully ({:.2f} ms)", filename, t));
 }
 
 unsigned char* Image::data() {
@@ -255,7 +256,7 @@ void Image::allocateOrResizeData() {
     if (dataSize == 0) {
         throw Err(
             9012,
-            std::format(
+            sgctcompat::format(
                 "Invalid image size {}x{} {} channels",
                 _size.x, _size.y, _nChannels
             )
@@ -273,7 +274,7 @@ void Image::allocateOrResizeData() {
         _data = new unsigned char[dataSize];
         _dataSize = dataSize;
 
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "Allocated {} bytes for image data ({:.2f} ms)",
             _dataSize, (time() - t0) * 1000.0
         ));

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -11,6 +11,7 @@
 #include <sgct/format.h>
 #include <sgct/networkmanager.h>
 #include <sgct/mutexes.h>
+#include <sgct/format_compat.h>
 #include <cstdarg>
 #include <fstream>
 #include <iostream>
@@ -64,10 +65,10 @@ void Log::printv(Level level, std::string message) {
         timeInfoPtr = localtime(&now);
         strftime(timeBuffer.data(), TimeBufferSize, "%X", timeInfoPtr);
 
-        message = std::format("{} | {}", timeBuffer.data(), message);
+        message = sgctcompat::format("{} | {}", timeBuffer.data(), message);
     }
     if (_showLevel) {
-        message = std::format("({}) {}", levelToString(level), message);
+        message = sgctcompat::format("({}) {}", levelToString(level), message);
     }
 
     if (_logToConsole) {

--- a/src/networkmanager.cpp
+++ b/src/networkmanager.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstring>
 #include <numeric>
+#include <sgct/format_compat.h>
 
 #ifdef WIN32
     #include <ws2tcpip.h>
@@ -180,7 +181,7 @@ NetworkManager::NetworkManager(NetworkMode nm,
 #endif // __APPLE__
     if (result != 0) {
             std::string err = std::to_string(Network::lastError());
-            throw Error(5028, std::format("Failed to get address info: {}", err));
+            throw Error(5028, sgctcompat::format("Failed to get address info: {}", err));
         }
     }
     std::vector<std::string> dnsNames;
@@ -214,7 +215,7 @@ NetworkManager::NetworkManager(NetworkMode nm,
 
     Log::Debug("Detected local addresses:");
     for (const std::string& address : _localAddresses) {
-        Log::Debug(std::format("  {}", address));
+        Log::Debug(sgctcompat::format("  {}", address));
     }
 }
 
@@ -301,7 +302,7 @@ void NetworkManager::initialize() {
             {
                 throw Error(
                     5023,
-                    std::format(
+                    sgctcompat::format(
                         "Port {} is already used by connection {}",
                         cm.thisNode().syncPort(), i
                     )
@@ -350,7 +351,7 @@ void NetworkManager::initialize() {
                     [](const char* data, int length) {
                         std::vector<char> d(data, data + length);
                         d.push_back('\0');
-                        Log::Info(std::format("[client]: {} [end]", d.data()));
+                        Log::Info(sgctcompat::format("[client]: {} [end]", d.data()));
                     }
                 );
 
@@ -379,7 +380,7 @@ void NetworkManager::initialize() {
     }
 
     Log::Debug(
-        std::format("Cluster sync: {}", cm.firmFrameLockSyncStatus() ? "firm" : "loose")
+        sgctcompat::format("Cluster sync: {}", cm.firmFrameLockSyncStatus() ? "firm" : "loose")
     );
 }
 
@@ -494,7 +495,7 @@ const Network& NetworkManager::syncConnection(int index) const {
 }
 
 void NetworkManager::updateConnectionStatus(Network& connection) {
-    Log::Debug(std::format("Updating status for connection {}", connection.id()));
+    Log::Debug(sgctcompat::format("Updating status for connection {}", connection.id()));
 
     int nConnections = 0;
     int nConnectedSync = 0;
@@ -519,13 +520,13 @@ void NetworkManager::updateConnectionStatus(Network& connection) {
         }
     }
 
-    Log::Info(std::format(
+    Log::Info(sgctcompat::format(
         "Number of active connections {} of {}", nConnections, totalNConnections
     ));
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "Number of connected sync nodes {} of {}", nConnectedSync, totalNSyncConnections
     ));
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "Number of connected data transfer nodes {} of {}",
         nConnectedDataTransfer, totalNTransferConnections
     ));
@@ -602,11 +603,11 @@ void NetworkManager::addConnection(int port, std::string address,
     ZoneScoped;
 
     if (port == 0) {
-        throw Error(5025, std::format("No port provided for connection to {}", address));
+        throw Error(5025, sgctcompat::format("No port provided for connection to {}", address));
     }
 
     if (address.empty()) {
-        throw Error(5026, std::format("Empty address for connection to {}", port));
+        throw Error(5026, sgctcompat::format("Empty address for connection to {}", port));
     }
 
     auto net = std::make_unique<Network>(
@@ -615,7 +616,7 @@ void NetworkManager::addConnection(int port, std::string address,
         _isServer,
         connectionType
     );
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "Initiating connection {} at port {}", _networkConnections.size(), port
     ));
     net->setUpdateFunction([this](Network& c) { updateConnectionStatus(c); });

--- a/src/offscreenbuffer.cpp
+++ b/src/offscreenbuffer.cpp
@@ -12,6 +12,7 @@
 #include <sgct/log.h>
 #include <sgct/opengl.h>
 #include <algorithm>
+#include <sgct/format_compat.h>
 
 // @TODO (abock, 2020-01-07) It would probably be better to only create a single offscreen
 // buffer of the maximum window size and reuse that between all windows.  That way we
@@ -85,7 +86,7 @@ void OffScreenBuffer::createFBO(int width, int height, int samples) {
             samples = 0;
         }
 
-        Log::Debug(std::format("Max samples supported: {}", maxSamples));
+        Log::Debug(sgctcompat::format("Max samples supported: {}", maxSamples));
 
         // generate the multisample buffer
         glGenFramebuffers(1, &_multiSampledFrameBuffer);
@@ -191,14 +192,14 @@ void OffScreenBuffer::createFBO(int width, int height, int samples) {
     );
 
     if (_isMultiSampled) {
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "Created {}x{} buffers: FBO id={}  Multisample FBO id={}"
             "RBO depth buffer id={}  RBO color buffer id={}", width, height,
             _frameBuffer, _multiSampledFrameBuffer, _depthBuffer, _colorBuffer
         ));
     }
     else {
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "Created {}x{} buffers: FBO id={}  RBO Depth buffer id={}",
             width, height, _frameBuffer, _depthBuffer
         ));

--- a/src/projection/cubemap.cpp
+++ b/src/projection/cubemap.cpp
@@ -13,6 +13,7 @@
 #include <sgct/offscreenbuffer.h>
 #include <sgct/opengl.h>
 #include <sgct/profiling.h>
+#include <sgct/format_compat.h>
 #include <glm/gtc/matrix_transform.hpp>
 
 #ifdef SGCT_HAS_SPOUT
@@ -183,7 +184,7 @@ void CubemapProjection::render(const BaseViewport& viewport,
                 _cubemapResolution.y
             );
             if (!s) {
-                Log::Error(std::format(
+                Log::Error(sgctcompat::format(
                     "Error sending texture '{}' for face {}", _cubeFaces[i].texture, i
                 ));
             }
@@ -242,7 +243,7 @@ void CubemapProjection::initTextures(unsigned int internalFormat, unsigned int f
     Log::Debug("CubemapProjection initTextures");
 
     for (int i = 0; i < 6; i++) {
-        Log::Debug(std::format("CubemapProjection initTextures {}", i));
+        Log::Debug(sgctcompat::format("CubemapProjection initTextures {}", i));
         if (!_cubeFaces[i].enabled) {
             continue;
         }
@@ -281,14 +282,14 @@ void CubemapProjection::initTextures(unsigned int internalFormat, unsigned int f
                 const std::string fullName =
                     _spoutName.empty() ?
                     CubeMapFaceName[i] :
-                    std::format("{}-{}", _spoutName, CubeMapFaceName[i]);
+                    sgctcompat::format("{}-{}", _spoutName, CubeMapFaceName[i]);
                 bool success = h->CreateSender(
                     fullName.c_str(),
                     _cubemapResolution.x,
                     _cubemapResolution.y
                 );
                 if (!success) {
-                    Log::Error(std::format(
+                    Log::Error(sgctcompat::format(
                         "Error creating SPOUT handle for {}", CubeMapFaceName[i]
                     ));
                 }
@@ -302,7 +303,7 @@ void CubemapProjection::initTextures(unsigned int internalFormat, unsigned int f
                 "Right", "zLeft", "Bottom", "Top", "Left", "zRight"
             };
 
-            _cubeFaces[i].ndi.name = std::format("{}-{}", _ndiName, CubeMapFaceName[i]);
+            _cubeFaces[i].ndi.name = sgctcompat::format("{}-{}", _ndiName, CubeMapFaceName[i]);
 
             NDIlib_send_create_t createDesc;
             createDesc.p_ndi_name = _cubeFaces[i].ndi.name.c_str();

--- a/src/projection/nonlinearprojection.cpp
+++ b/src/projection/nonlinearprojection.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <sgct/format_compat.h>
 
 namespace sgct {
 
@@ -116,7 +117,7 @@ void NonLinearProjection::initTextures(unsigned int internalFormat, unsigned int
                                        unsigned int type)
 {
     generateCubeMap(_textures.cubeMapColor, internalFormat, format, type);
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "{}x{} color cube map texture (id: {}) generated",
         _cubemapResolution.x, _cubemapResolution.y, _textures.cubeMapColor
     ));
@@ -128,7 +129,7 @@ void NonLinearProjection::initTextures(unsigned int internalFormat, unsigned int
             GL_DEPTH_COMPONENT,
             GL_FLOAT
         );
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "{}x{} depth cube map texture (id: {}) generated",
             _cubemapResolution.x, _cubemapResolution.y, _textures.cubeMapDepth
         ));
@@ -141,13 +142,13 @@ void NonLinearProjection::initTextures(unsigned int internalFormat, unsigned int
                 GL_DEPTH_COMPONENT,
                 GL_FLOAT
             );
-            Log::Debug(std::format(
+            Log::Debug(sgctcompat::format(
                 "{}x{} depth swap map texture (id: {}) generated",
                 _cubemapResolution.x, _cubemapResolution.y, _textures.depthSwap
             ));
 
             generateMap(_textures.colorSwap, internalFormat, format, type);
-            Log::Debug(std::format(
+            Log::Debug(sgctcompat::format(
                 "{}x{} color swap map texture (id: {}) generated",
                 _cubemapResolution.x, _cubemapResolution.y, _textures.colorSwap
             ));
@@ -156,7 +157,7 @@ void NonLinearProjection::initTextures(unsigned int internalFormat, unsigned int
 
     if (Engine::instance().settings().useNormalTexture) {
         generateCubeMap(_textures.cubeMapNormals, GL_RGB32F, GL_RGB, GL_FLOAT);
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "{}x{} normal cube map texture (id: {}) generated",
             _cubemapResolution.x, _cubemapResolution.y, _textures.cubeMapNormals
         ));
@@ -164,7 +165,7 @@ void NonLinearProjection::initTextures(unsigned int internalFormat, unsigned int
 
     if (Engine::instance().settings().usePositionTexture) {
         generateCubeMap(_textures.cubeMapPositions, GL_RGB32F, GL_RGB, GL_FLOAT);
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "{}x{} position cube map texture ({}) generated",
             _cubemapResolution.x, _cubemapResolution.y, _textures.cubeMapPositions
         ));
@@ -196,12 +197,12 @@ void NonLinearProjection::generateMap(unsigned int& texture, unsigned int intern
     GLint maxMapRes = 0;
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxMapRes);
     if (_cubemapResolution.x > maxMapRes) {
-        Log::Error(std::format(
+        Log::Error(sgctcompat::format(
             "Requested size is too big ({} > {})", _cubemapResolution.x, maxMapRes
         ));
     }
     if (_cubemapResolution.y > maxMapRes) {
-        Log::Error(std::format(
+        Log::Error(sgctcompat::format(
             "Requested size is too big ({} > {})", _cubemapResolution.y, maxMapRes
         ));
     }
@@ -245,11 +246,11 @@ void NonLinearProjection::generateCubeMap(unsigned int& texture,
     glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, &maxCubeMapRes);
     if (_cubemapResolution.x > maxCubeMapRes) {
         _cubemapResolution.x = maxCubeMapRes;
-        Log::Debug(std::format("Cubemap size set to max size: {}", maxCubeMapRes));
+        Log::Debug(sgctcompat::format("Cubemap size set to max size: {}", maxCubeMapRes));
     }
     if (_cubemapResolution.y > maxCubeMapRes) {
         _cubemapResolution.y = maxCubeMapRes;
-        Log::Debug(std::format("Cubemap size set to max size: {}", maxCubeMapRes));
+        Log::Debug(sgctcompat::format("Cubemap size set to max size: {}", maxCubeMapRes));
     }
 
 

--- a/src/projection/sphericalmirror.cpp
+++ b/src/projection/sphericalmirror.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
+#include <sgct/format_compat.h>
 
 namespace {
     constexpr std::string_view SphericalProjectionVert = R"(
@@ -191,7 +192,7 @@ void SphericalMirrorProjection::initTextures(unsigned int internalFormat,
             return;
         }
         generateMap(texture, internalFormat, format, type);
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "{}x{} cube face texture (id: {}) generated",
             _cubemapResolution.x, _cubemapResolution.y, texture
         ));

--- a/src/screencapture.cpp
+++ b/src/screencapture.cpp
@@ -18,6 +18,7 @@
 #include <sgct/window.h>
 #include <cstring>
 #include <string>
+#include <sgct/format_compat.h>
 
 namespace sgct {
 
@@ -37,7 +38,7 @@ ScreenCapture::ScreenCapture(const Window& window, ScreenCapture::EyeIndex ei,
         _captureInfos[i].mutex = &_mutex;
         _captureInfos[i].isRunning = false;
     }
-    Log::Debug(std::format("Number of screencapture threads is set to {}", _nThreads));
+    Log::Debug(sgctcompat::format("Number of screencapture threads is set to {}", _nThreads));
 }
 
 ScreenCapture::~ScreenCapture() {
@@ -78,7 +79,7 @@ void ScreenCapture::resize(ivec2 resolution) {
     }
 
     glGenBuffers(1, &_pbo);
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "Generating {}x{}x{} PBO: {}", _resolution.x, _resolution.y, nChannels, _pbo
     ));
 
@@ -96,7 +97,7 @@ void ScreenCapture::saveScreenCapture(unsigned int textureId, CaptureSource capS
         uint64_t end = Engine::instance().settings().capture.limits->second;
 
         if (number < begin || number >= end) {
-            Log::Debug(std::format(
+            Log::Debug(sgctcompat::format(
                 "Skipping screenshot {} outside range [{}, {}]", number, begin, end
             ));
             return;
@@ -198,7 +199,7 @@ std::string ScreenCapture::createFilename(uint64_t frameNumber) {
 
     std::array<char, 6> Buffer = {};
     std::fill(Buffer.begin(), Buffer.end(), '\0');
-    std::format_to_n(Buffer.data(), Buffer.size(), "{:06}", frameNumber);
+    sgctcompat::format_to_n(Buffer.data(), Buffer.size(), "{:06}", frameNumber);
 
     std::filesystem::path file;
     if (!Engine::instance().settings().capture.capturePath.empty()) {
@@ -211,11 +212,11 @@ std::string ScreenCapture::createFilename(uint64_t frameNumber) {
     if (Engine::instance().settings().capture.addNodeName &&
         ClusterManager::instance().numberOfNodes() > 1)
     {
-        file += std::format("node{}_", ClusterManager::instance().thisNodeId());
+        file += sgctcompat::format("node{}_", ClusterManager::instance().thisNodeId());
     }
     if (Engine::instance().settings().capture.addWindowName) {
         file +=
-            _window.name().empty() ? std::format("win{}", _window.id()) : _window.name();
+            _window.name().empty() ? sgctcompat::format("win{}", _window.id()) : _window.name();
         file += '_';
     }
 
@@ -223,7 +224,7 @@ std::string ScreenCapture::createFilename(uint64_t frameNumber) {
         file += eyeSuffix + '_';
     }
 
-    return std::format("{}{}.png", file, std::string(Buffer.begin(), Buffer.end()));
+    return sgctcompat::format("{}{}.png", file, std::string(Buffer.begin(), Buffer.end()));
 }
 
 int ScreenCapture::availableCaptureThread() {
@@ -247,7 +248,7 @@ int ScreenCapture::availableCaptureThread() {
 }
 
 Image* ScreenCapture::prepareImage(int index, std::string file) {
-    Log::Debug(std::format("Starting thread for screenshot/capture [{}]", index));
+    Log::Debug(sgctcompat::format("Starting thread for screenshot/capture [{}]", index));
 
     if (_captureInfos[index].frameBufferImage == nullptr) {
         const int nChannels = _addAlpha ? 4 : 3;

--- a/src/shadermanager.cpp
+++ b/src/shadermanager.cpp
@@ -13,6 +13,7 @@
 #include <sgct/log.h>
 #include <sgct/opengl.h>
 #include <algorithm>
+#include <sgct/format_compat.h>
 
 #define Error(code, msg) Error(Error::Component::Shader, code, msg)
 
@@ -45,7 +46,7 @@ void ShaderManager::addShaderProgram(std::string name, std::string_view vertexSr
     if (shaderProgramExists(name)) {
         throw Error(
             7000,
-            std::format("Cannot add shader program '{}': Already exists", name)
+            sgctcompat::format("Cannot add shader program '{}': Already exists", name)
         );
     }
 
@@ -66,7 +67,7 @@ bool ShaderManager::removeShaderProgram(std::string_view name) {
 
     if (shaderIt == _shaderPrograms.end()) {
         Log::Warning(
-            std::format("Unable to remove shader program '{}': Not found", name)
+            sgctcompat::format("Unable to remove shader program '{}': Not found", name)
         );
         return false;
     }
@@ -84,7 +85,7 @@ const ShaderProgram& ShaderManager::shaderProgram(std::string_view name) const {
         [name](const ShaderProgram& prg) { return prg.name() == name; }
     );
     if (shaderIt == _shaderPrograms.end()) {
-        throw Error(7001, std::format("Could not find shader with name '{}'", name));
+        throw Error(7001, sgctcompat::format("Could not find shader with name '{}'", name));
     }
     return *shaderIt;
 }

--- a/src/shaderprogram.cpp
+++ b/src/shaderprogram.cpp
@@ -12,6 +12,7 @@
 #include <sgct/format.h>
 #include <sgct/log.h>
 #include <sgct/opengl.h>
+#include <sgct/format_compat.h>
 
 #define Err(code, msg) Error(Error::Component::Shader, code, msg)
 
@@ -28,7 +29,7 @@ namespace {
             glGetProgramInfoLog(programId, logLength, nullptr, log.data());
 
             sgct::Log::Error(
-                std::format("Shader '{}' linking error: {}", name, log.data())
+                sgctcompat::format("Shader '{}' linking error: {}", name, log.data())
             );
         }
         return linkStatus != 0;
@@ -52,14 +53,14 @@ namespace {
             glGetShaderiv(id, GL_INFO_LOG_LENGTH, &logLength);
 
             if (logLength == 0) {
-                sgct::Log::Error(std::format(
+                sgct::Log::Error(sgctcompat::format(
                     "{} compile error: Unknown error", shaderTypeName(type)
                 ));
             }
 
             std::vector<GLchar> log(logLength);
             glGetShaderInfoLog(id, logLength, nullptr, log.data());
-            sgct::Log::Error(std::format(
+            sgct::Log::Error(sgctcompat::format(
                 "{} compile error: {}", shaderTypeName(type), log.data()
             ));
         }
@@ -147,7 +148,7 @@ void ShaderProgram::createAndLinkProgram() {
     if (_shaders.empty()) {
         throw Err(
             7010,
-            std::format("No shaders have been added to the program '{}'", _name)
+            sgctcompat::format("No shaders have been added to the program '{}'", _name)
         );
     }
 
@@ -161,7 +162,7 @@ void ShaderProgram::createAndLinkProgram() {
     glLinkProgram(_programId);
     const bool isLinked = checkLinkStatus(_programId, _name);
     if (!isLinked) {
-        throw Err(7011, std::format("Error linking the program '{}'", _name));
+        throw Err(7011, sgctcompat::format("Error linking the program '{}'", _name));
     }
 }
 
@@ -169,7 +170,7 @@ void ShaderProgram::createProgram() {
     if (_programId > 0) {
         throw Err(
             7012,
-            std::format("Failed to create shader program '{}': Already created", _name)
+            sgctcompat::format("Failed to create shader program '{}': Already created", _name)
         );
     }
 
@@ -177,7 +178,7 @@ void ShaderProgram::createProgram() {
     if (_programId == 0) {
         throw Err(
             7013,
-            std::format("Failed to create shader program '{}': Unknown error", _name)
+            sgctcompat::format("Failed to create shader program '{}': Unknown error", _name)
         );
     }
 }

--- a/src/statisticsrenderer.cpp
+++ b/src/statisticsrenderer.cpp
@@ -18,6 +18,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <algorithm>
+#include <sgct/format_compat.h>
 
 namespace {
     // Line parameters
@@ -375,7 +376,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y + 9 * penOffset,
             vec4{ 1.f, 0.8f, 0.8f, 1.f },
-            std::format("Frame number: {}", Engine::instance().currentFrameNumber())
+            sgctcompat::format("Frame number: {}", Engine::instance().currentFrameNumber())
         );
         text::print(
             window,
@@ -384,7 +385,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y + 6 * penOffset,
             ColorFrameTime,
-            std::format("Frame time: {} ms", _statistics.frametimes[0] * 1000.0)
+            sgctcompat::format("Frame time: {} ms", _statistics.frametimes[0] * 1000.0)
         );
         text::print(
             window,
@@ -393,7 +394,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y + 5 * penOffset,
             ColorDrawTime,
-            std::format("Draw time: {} ms", _statistics.drawTimes[0] * 1000.0)
+            sgctcompat::format("Draw time: {} ms", _statistics.drawTimes[0] * 1000.0)
         );
         text::print(
             window,
@@ -402,7 +403,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y + 4 * penOffset,
             ColorSyncTime,
-            std::format("Sync time: {} ms", _statistics.syncTimes[0] * 1000.0)
+            sgctcompat::format("Sync time: {} ms", _statistics.syncTimes[0] * 1000.0)
         );
         text::print(
             window,
@@ -411,7 +412,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y + 3 * penOffset,
             ColorLoopTimeMin,
-            std::format("Min Loop time: {} ms", _statistics.loopTimeMin[0] * 1000.0)
+            sgctcompat::format("Min Loop time: {} ms", _statistics.loopTimeMin[0] * 1000.0)
         );
         text::print(
             window,
@@ -420,7 +421,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y + 2 * penOffset,
             ColorLoopTimeMax,
-            std::format("Max Loop time: {} ms", _statistics.loopTimeMax[0] * 1000.0)
+            sgctcompat::format("Max Loop time: {} ms", _statistics.loopTimeMax[0] * 1000.0)
         );
 #endif // SGCT_HAS_TEXT
     }
@@ -487,7 +488,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y + penOffset,
             vec4{ 0.8f, 0.8f, 0.8f, 1.f },
-            std::format(
+            sgctcompat::format(
                 "Histogram Scale (sync time): {:.0f} ms",
                 HistogramScaleSync * 1000.0
             )
@@ -499,7 +500,7 @@ void StatisticsRenderer::render(const Window& window, const Viewport& viewport) 
             mode,
             penPosition.x, penPosition.y,
             vec4{ 0.8f, 0.8f, 0.8f, 1.f },
-            std::format(
+            sgctcompat::format(
                 "Histogram Scale (frametime, drawtime): {:.0f} ms",
                 HistogramScaleFrame * 1000.0
             )

--- a/src/texturemanager.cpp
+++ b/src/texturemanager.cpp
@@ -13,6 +13,7 @@
 #include <sgct/log.h>
 #include <sgct/opengl.h>
 #include <algorithm>
+#include <sgct/format_compat.h>
 
 namespace {
     unsigned int uploadImage(const sgct::Image& img, bool interpolate, int mipmap,
@@ -32,7 +33,7 @@ namespace {
             }
         }(img.channels());
 
-        sgct::Log::Debug(std::format(
+        sgct::Log::Debug(sgctcompat::format(
             "Creating texture. Size: {}x{}, {}-channels, Type: {:#04x}, Format: {:#04x}",
             img.size().x, img.size().y, img.channels(), type, internalFormat
         ));
@@ -143,7 +144,7 @@ unsigned int TextureManager::loadTexture(const std::filesystem::path& filename,
         anisotropicFilterSize,
         mipmapLevels
     );
-    Log::Debug(std::format("Texture created from '{}' [id={}]", filename, t));
+    Log::Debug(sgctcompat::format("Texture created from '{}' [id={}]", filename, t));
     return t;
 }
 

--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -16,6 +16,7 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <algorithm>
+#include <sgct/format_compat.h>
 
 namespace sgct {
 
@@ -29,7 +30,7 @@ void Tracker::setEnabled(bool state) {
 
 void Tracker::addDevice(std::string name, int index) {
     _trackingDevices.push_back(std::make_unique<TrackingDevice>(index, name));
-    Log::Info(std::format("{}: Adding device '{}'", _name, name));
+    Log::Info(sgctcompat::format("{}: Adding device '{}'", _name, name));
 }
 
 const std::vector<std::unique_ptr<TrackingDevice>>& Tracker::devices() const {

--- a/src/trackingdevice.cpp
+++ b/src/trackingdevice.cpp
@@ -21,6 +21,7 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <algorithm>
+#include <sgct/format_compat.h>
 
 namespace sgct {
 
@@ -62,7 +63,7 @@ void TrackingDevice::setSensorTransform(vec3 vec, quat rot) {
 #endif
 
     if (parent == nullptr) {
-        Log::Error(std::format("Error getting handle to tracker for device '{}'", _name));
+        Log::Error(sgctcompat::format("Error getting handle to tracker for device '{}'", _name));
         return;
     }
 

--- a/src/trackingmanager.cpp
+++ b/src/trackingmanager.cpp
@@ -33,6 +33,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/euler_angles.hpp>
 #include <algorithm>
+#include <sgct/format_compat.h>
 
 namespace {
     struct VRPNPointer {
@@ -220,7 +221,7 @@ void TrackingManager::startSampling() {
     }
 
     if (_head == nullptr && !trackerName.empty() && !deviceName.empty()) {
-        Log::Error(std::format(
+        Log::Error(sgctcompat::format(
             "Failed to set head tracker to {}@{}", deviceName, trackerName
         ));
         return;
@@ -245,10 +246,10 @@ void TrackingManager::addTracker(std::string name) {
     if (!tracker(name)) {
         _trackers.push_back(std::make_unique<Tracker>(name));
         gTrackers.emplace_back(std::vector<VRPNPointer>());
-        Log::Info(std::format("Tracker '{}' added successfully", name));
+        Log::Info(sgctcompat::format("Tracker '{}' added successfully", name));
     }
     else {
-        Log::Warning(std::format("Tracker '{}' already exists", name));
+        Log::Warning(sgctcompat::format("Tracker '{}' already exists", name));
     }
 }
 
@@ -271,7 +272,7 @@ void TrackingManager::addSensorToCurrentDevice(std::string address, int id) {
         device->setSensorId(id);
 
         if (retVal.second && ptr.sensorDevice == nullptr) {
-            Log::Info(std::format("Connecting to sensor '{}'", address));
+            Log::Info(sgctcompat::format("Connecting to sensor '{}'", address));
             ptr.sensorDevice = std::make_unique<vrpn_Tracker_Remote>(address.c_str());
             ptr.sensorDevice->register_change_handler(
                 _trackers.back().get(),
@@ -280,7 +281,7 @@ void TrackingManager::addSensorToCurrentDevice(std::string address, int id) {
         }
     }
     else {
-        Log::Error(std::format("Failed to connect to sensor '{}'", address));
+        Log::Error(sgctcompat::format("Failed to connect to sensor '{}'", address));
     }
 }
 
@@ -293,7 +294,7 @@ void TrackingManager::addButtonsToCurrentDevice(std::string address, int nButton
     TrackingDevice* device = _trackers.back()->devices().back().get();
 
     if (ptr.buttonDevice == nullptr && device) {
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Connecting to buttons '{}' on device {}", address, device->name()
         ));
         ptr.buttonDevice = std::make_unique<vrpn_Button_Remote>(address.c_str());
@@ -301,7 +302,7 @@ void TrackingManager::addButtonsToCurrentDevice(std::string address, int nButton
         device->setNumberOfButtons(nButtons);
     }
     else {
-        Log::Error(std::format("Failed to connect to buttons '{}'", address));
+        Log::Error(sgctcompat::format("Failed to connect to buttons '{}'", address));
     }
 }
 
@@ -314,7 +315,7 @@ void TrackingManager::addAnalogsToCurrentDevice(std::string address, int nAxes) 
     TrackingDevice* device = _trackers.back()->devices().back().get();
 
     if (ptr.analogDevice == nullptr && device) {
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "Connecting to analog '{}' on device {}", address, device->name()
         ));
 
@@ -323,7 +324,7 @@ void TrackingManager::addAnalogsToCurrentDevice(std::string address, int nAxes) 
         device->setNumberOfAxes(nAxes);
     }
     else {
-        Log::Error(std::format("Failed to connect to analogs '{}'", address));
+        Log::Error(sgctcompat::format("Failed to connect to analogs '{}'", address));
     }
 }
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <optional>
 #include <variant>
+#include <sgct/format_compat.h>
 
 namespace {
     // Helper structs for the visitor pattern of the std::variant on projections
@@ -57,7 +58,7 @@ Viewport::Viewport(const config::Viewport& viewport, const Window& parent)
         User* user = ClusterManager::instance().user(*viewport.user);
         if (!user) {
             Log::Warning(
-                std::format("Could not find user with name '{}'", *viewport.user)
+                sgctcompat::format("Could not find user with name '{}'", *viewport.user)
             );
         }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -57,6 +57,7 @@
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
+#include <sgct/format_compat.h>
 
 #define Err(code, msg) Error(Error::Component::Window, code, msg)
 
@@ -209,14 +210,14 @@ void Window::initNvidiaSwapGroups() {
         if (res == GL_FALSE) {
             throw Err(3006, "Error requesting maximum number of swap groups");
         }
-        Log::Info(std::format(
+        Log::Info(sgctcompat::format(
             "WGL_NV_swap_group extension is supported. Max number of groups: {}. "
             "Max number of barriers: {}", maxGroup, maxBarrier
         ));
 
         if (maxGroup > 0) {
             _useSwapGroups = wglJoinSwapGroupNV(hDC, 1) == GL_TRUE;
-            Log::Info(std::format(
+            Log::Info(sgctcompat::format(
                 "Joining swapgroup 1 [{}]", _useSwapGroups ? "ok" : "failed"
             ));
         }
@@ -292,7 +293,7 @@ config::Window createScalableConfiguration([[maybe_unused]]
         throw Error(
             sgct::Error::Component::Config,
             1104,
-            std::format(
+            sgctcompat::format(
                 "Could not read ScalableMesh '{}' with error: {}", scalable.mesh, err
             )
         );
@@ -362,7 +363,7 @@ config::Window createScalableConfiguration([[maybe_unused]]
         throw Error(
             sgct::Error::Component::Config,
             1104,
-            std::format(
+            sgctcompat::format(
                 "Could not read ScalableMesh '{}' with error: Unknown projection type {}",
                 scalable.mesh, mesh.Projection
             )
@@ -508,7 +509,7 @@ void Window::openWindow(GLFWwindow* share, bool isLastWindow) {
 
     if (_stereoMode == StereoMode::Active) {
         glfwWindowHint(GLFW_STEREO, GLFW_TRUE);
-        Log::Info(std::format("Window {}: Enabling quadbuffered rendering", _id));
+        Log::Info(sgctcompat::format("Window {}: Enabling quadbuffered rendering", _id));
     }
 
     GLFWmonitor* mon = nullptr;
@@ -523,7 +524,7 @@ void Window::openWindow(GLFWwindow* share, bool isLastWindow) {
         else {
             mon = glfwGetPrimaryMonitor();
             if (_monitorIndex >= count) {
-                Log::Info(std::format(
+                Log::Info(sgctcompat::format(
                     "Window({}): Invalid monitor index ({}). Computer has {} monitors",
                     _id, _monitorIndex, count
                 ));
@@ -660,7 +661,7 @@ void Window::openWindow(GLFWwindow* share, bool isLastWindow) {
         );
     }
 
-    const std::string title = std::format(
+    const std::string title = sgctcompat::format(
         "SGCT node: {} ({}: {})",
         ClusterManager::instance().thisNode().address(),
         (NetworkManager::instance().isComputerServer() ? "server" : "client"),
@@ -708,22 +709,22 @@ void Window::closeWindow() {
 
     makeSharedContextCurrent();
 
-    Log::Info(std::format("Deleting screen capture data for window {}", _id));
+    Log::Info(sgctcompat::format("Deleting screen capture data for window {}", _id));
     _screenCaptureLeftOrMono = nullptr;
     _screenCaptureRight = nullptr;
 
     // delete FBO stuff
     if (_finalFBO) {
-        Log::Info(std::format("Releasing OpenGL buffers for window {}", _id));
+        Log::Info(sgctcompat::format("Releasing OpenGL buffers for window {}", _id));
         _finalFBO = nullptr;
         destroyFBOs();
     }
 
-    Log::Info(std::format("Deleting VBOs for window {}", _id));
+    Log::Info(sgctcompat::format("Deleting VBOs for window {}", _id));
     glDeleteBuffers(1, &_vbo);
     _vbo = 0;
 
-    Log::Info(std::format("Deleting VAOs for window {}", _id));
+    Log::Info(sgctcompat::format("Deleting VAOs for window {}", _id));
     glDeleteVertexArrays(1, &_vao);
     _vao = 0;
 
@@ -761,7 +762,7 @@ void Window::initialize() {
 
     _finalFBO->createFBO(_framebufferRes.x, _framebufferRes.y, _nAASamples);
 
-    Log::Debug(std::format(
+    Log::Debug(sgctcompat::format(
         "Window {}: FBO initiated successfully. Number of samples: {}",
         _id, _finalFBO->isMultiSampled() ? _nAASamples : 1
     ));
@@ -795,7 +796,7 @@ void Window::initialize() {
             );
         }
         if (!success) {
-            Log::Error(std::format("Error creating SPOUT handle for {}", _spoutName));
+            Log::Error(sgctcompat::format("Error creating SPOUT handle for {}", _spoutName));
         }
     }
 #endif // SGCT_HAS_SPOUT
@@ -856,7 +857,7 @@ void Window::updateResolutions() {
         // adjusting only the horizontal (x) values
         for (const std::unique_ptr<Viewport>& vp : _viewports) {
             vp->updateFovToMatchAspectRatio(_aspectRatio, ratio);
-            Log::Debug(std::format(
+            Log::Debug(sgctcompat::format(
                 "Update aspect ratio in viewport ({} -> {})", _aspectRatio, ratio
             ));
         }
@@ -865,7 +866,7 @@ void Window::updateResolutions() {
         // Redraw window
         glfwSetWindowSize(_windowHandle, _windowRes->x, _windowRes->y);
 
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "Resolution changed to {}x{} in window {}", _windowRes->x, _windowRes->y, _id
         ));
         _pendingWindowRes = std::nullopt;
@@ -894,7 +895,7 @@ void Window::updateResolutions() {
     if (_pendingFramebufferRes) {
         _framebufferRes = *_pendingFramebufferRes;
 
-        Log::Debug(std::format(
+        Log::Debug(sgctcompat::format(
             "Framebuffer resolution changed to {}x{} for window {}",
             _framebufferRes.x, _framebufferRes.y, _id
         ));
@@ -1127,7 +1128,7 @@ void Window::renderFBOTexture() {
             _framebufferRes.y
         );
         if (!s) {
-            Log::Error(std::format("Error sending Spout texture for '{}'", _spoutName));
+            Log::Error(sgctcompat::format("Error sending Spout texture for '{}'", _spoutName));
         }
     }
 #endif // SGCT_HAS_SPOUT
@@ -1398,7 +1399,7 @@ void Window::setHorizFieldOfView(float hFovDeg) {
     for (const std::unique_ptr<Viewport>& vp : _viewports) {
         vp->setHorizontalFieldOfView(hFovDeg);
     }
-    Log::Debug(std::format("HFOV changed to {} for window {}", hFovDeg, _id));
+    Log::Debug(sgctcompat::format("HFOV changed to {} for window {}", hFovDeg, _id));
 }
 
 float Window::horizFieldOfViewDegrees() const {
@@ -1433,7 +1434,7 @@ void Window::createTextures() {
     GLint max = 0;
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max);
     if (_framebufferRes.x > max || _framebufferRes.y > max) {
-        Log::Error(std::format(
+        Log::Error(sgctcompat::format(
             "Window {}: Requested framebuffer too big (Max: {})", _id, max
         ));
         return;
@@ -1458,7 +1459,7 @@ void Window::createTextures() {
         generateTexture(_frameBufferTextures.positions, TextureType::Position);
     }
 
-    Log::Debug(std::format("Targets initialized successfully for window {}", _id));
+    Log::Debug(sgctcompat::format("Targets initialized successfully for window {}", _id));
 }
 
 void Window::generateTexture(unsigned int& id, Window::TextureType type) {
@@ -1498,7 +1499,7 @@ void Window::generateTexture(unsigned int& id, Window::TextureType type) {
         std::get<2>(formats),
         nullptr
     );
-    Log::Debug(std::format("{}x{} texture generated for window {}", res.x, res.y, id));
+    Log::Debug(sgctcompat::format("{}x{} texture generated for window {}", res.x, res.y, id));
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,8 @@ find_package(Catch2 REQUIRED)
 target_link_libraries(SGCTTest PRIVATE Catch2::Catch2WithMain sgct::sgct nlohmann_json::nlohmann_json nlohmann_json_schema_validator::nlohmann_json_schema_validator glm::glm)
 
 if (APPLE)
-  target_link_libraries(SGCTTest PRIVATE ${CARBON_LIBRARY} ${COREFOUNDATION_LIBRARY} ${COCOA_LIBRARY} ${APP_SERVICES_LIBRARY})
+  find_package(fmt REQUIRED)
+  target_link_libraries(SGCTTest PRIVATE fmt::fmt ${CARBON_LIBRARY} ${COREFOUNDATION_LIBRARY} ${COCOA_LIBRARY} ${APP_SERVICES_LIBRARY})
 endif ()
 
 add_test(NAME SGCTTest COMMAND SGCTTest)

--- a/tests/test_config_load_cubemapprojection.cpp
+++ b/tests/test_config_load_cubemapprojection.cpp
@@ -13,6 +13,7 @@
 #include <sgct/math.h>
 #include <numeric>
 #include "schema.h"
+#include <sgct/format_compat.h>
 
 using namespace sgct;
 using namespace sgct::config;
@@ -1940,17 +1941,17 @@ TEST_CASE("Load: CubemapProjection/Channels", "[parse]") {
         std::vector<std::string> res2;
 
         res1.right = idx & 0b000001;
-        res2.push_back(std::format("\"right\": {}", idx & 0b000001 ? "true" : "false"));
+        res2.push_back(sgctcompat::format("\"right\": {}", idx & 0b000001 ? "true" : "false"));
         res1.zLeft = idx & 0b000010;
-        res2.push_back(std::format("\"zleft\": {}", idx & 0b000010 ? "true" : "false"));
+        res2.push_back(sgctcompat::format("\"zleft\": {}", idx & 0b000010 ? "true" : "false"));
         res1.bottom = idx & 0b000100;
-        res2.push_back(std::format("\"bottom\": {}", idx & 0b000100 ? "true" : "false"));
+        res2.push_back(sgctcompat::format("\"bottom\": {}", idx & 0b000100 ? "true" : "false"));
         res1.top = idx & 0b001000;
-        res2.push_back(std::format("\"top\": {}", idx & 0b001000 ? "true" : "false"));
+        res2.push_back(sgctcompat::format("\"top\": {}", idx & 0b001000 ? "true" : "false"));
         res1.left = idx & 0b010000;
-        res2.push_back(std::format("\"left\": {}", idx & 0b010000 ? "true" : "false"));
+        res2.push_back(sgctcompat::format("\"left\": {}", idx & 0b010000 ? "true" : "false"));
         res1.zRight = idx & 0b100000;
-        res2.push_back(std::format("\"zright\": {}", idx & 0b100000 ? "true" : "false"));
+        res2.push_back(sgctcompat::format("\"zright\": {}", idx & 0b100000 ? "true" : "false"));
 
         return std::pair(
             res1,
@@ -1966,7 +1967,7 @@ TEST_CASE("Load: CubemapProjection/Channels", "[parse]") {
     for (uint8_t i = 0; i < 0b111111; i++) {
         const auto& [value, string] = idxToChannels(i);
 
-        std::string String = std::format(R"(
+        std::string String = sgctcompat::format(R"(
 {{
   "version": 1,
   "masteraddress": "localhost",


### PR DESCRIPTION
Apple Clang doesn't seem to support std::format, needs fmt::format. So, a separate sgctcompat namespace is added in a separate header file, and all the std::format (and similar) calls are changed to sgctcompat::format etc. Tested building OK on Windows, Linux, AppleSilicon as well as Intel Mac. https://github.com/hn-88/sgct-test-builds/actions