### PR TITLE
CMake updates for correct inclusion as external in another project.

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -182,6 +182,7 @@ if (WIN32 AND SGCT_SPOUT_SUPPORT)
   add_library(spout SHARED IMPORTED GLOBAL)
   target_include_directories(spout INTERFACE spout)
   set_property(TARGET spout PROPERTY IMPORTED_IMPLIB ${PROJECT_SOURCE_DIR}/ext/spout/SpoutLibrary.lib)
+  set_property(TARGET spout PROPERTY IMPORTED_IMPLIB_RELEASE ${PROJECT_SOURCE_DIR}/ext/spout/SpoutLibrary.lib)
   set_property(TARGET spout PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/ext/spout/SpoutLibrary.dll)
 endif ()
 

--- a/ext/ndi/CMakeLists.txt
+++ b/ext/ndi/CMakeLists.txt
@@ -14,4 +14,5 @@ add_library(ndi SHARED IMPORTED GLOBAL)
 
 target_include_directories(ndi SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(ndi PROPERTIES IMPORTED_IMPLIB ${CMAKE_CURRENT_SOURCE_DIR}/lib/Processing.NDI.Lib.x64.lib)
+set_target_properties(ndi PROPERTIES IMPORTED_IMPLIB_RELEASE ${CMAKE_CURRENT_SOURCE_DIR}/lib/Processing.NDI.Lib.x64.lib)
 set_target_properties(ndi PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/lib/Processing.NDI.Lib.x64.dll)

--- a/ext/scalable/CMakeLists.txt
+++ b/ext/scalable/CMakeLists.txt
@@ -15,4 +15,5 @@ add_library(scalable SHARED IMPORTED GLOBAL)
 
 target_include_directories(scalable SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(scalable PROPERTIES IMPORTED_IMPLIB ${CMAKE_CURRENT_SOURCE_DIR}/mplEasyBlendSDK.lib)
+set_target_properties(scalable PROPERTIES IMPORTED_IMPLIB_RELEASE ${CMAKE_CURRENT_SOURCE_DIR}/mplEasyBlendSDK.lib)
 set_target_properties(scalable PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/mplEasyBlendSDK.dll)

--- a/support/cmake/set_compile_options.cmake
+++ b/support/cmake/set_compile_options.cmake
@@ -7,8 +7,8 @@
 ##########################################################################################
 
 function (set_compile_options target)
-  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/support/cmake/common-compile-settings")
-  include(${PROJECT_SOURCE_DIR}/support/cmake/common-compile-settings/common-compile-settings.cmake)
+  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/common-compile-settings")
+  include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/common-compile-settings/common-compile-settings.cmake)
   set_compile_settings(${target})
 
   if (SGCT_ENABLE_EDIT_CONTINUE)


### PR DESCRIPTION
Would need to update submodule common-compile-settings with similar changes (there already pull request for that).