### PR TITLE
Updated fontmanager with minor modified system font path find lines.

### DIFF
--- a/include/sgct/fontmanager.h
+++ b/include/sgct/fontmanager.h
@@ -106,7 +106,7 @@ public:
      * \param name Specify a name for the font
      * \param file Path to the font file
      */
-    bool addFont(std::string name, std::string file);
+    bool addFont(std::string name, std::string file, bool absolutePath = false);
 
     /**
      * Get a font face that is loaded into memory.

--- a/include/sgct/fontmanager.h
+++ b/include/sgct/fontmanager.h
@@ -105,8 +105,10 @@ public:
      *
      * \param name Specify a name for the font
      * \param file Path to the font file
+     * \param isAbsolutePath If this value is `true`, the \p file specifies an absolute
+     *        path
      */
-    bool addFont(std::string name, std::string file, bool absolutePath = false);
+    bool addFont(std::string name, std::string file, bool isAbsolutePath = false);
 
     /**
      * Get a font face that is loaded into memory.

--- a/src/fontmanager.cpp
+++ b/src/fontmanager.cpp
@@ -134,9 +134,10 @@ void FontManager::bindShader(const mat4& mvp, const vec4& color, int texture) co
     glUniformMatrix4fv(_mvpLocation, 1, GL_FALSE, mvp.values.data());
 }
 
-bool FontManager::addFont(std::string name, std::string file) {
+bool FontManager::addFont(std::string name, std::string file, bool absolutePath) {
     // Perform file exists check
-    file = SystemFontPath + file;
+    if(!absolutePath)
+        file = SystemFontPath + file;
 
     const bool inserted = _fontPaths.insert({ name, std::move(file) }).second;
     if (!inserted) {

--- a/src/fontmanager.cpp
+++ b/src/fontmanager.cpp
@@ -97,12 +97,14 @@ FontManager::FontManager() {
 
     // Set default font path
 #ifdef WIN32
-    constexpr int BufferSize = 256;
-    char FontDir[BufferSize];
-    const UINT success = GetWindowsDirectory(FontDir, 256);
+    WCHAR winDir[MAX_PATH];
+    const UINT success = GetWindowsDirectory(winDir, MAX_PATH);
+
     if (success > 0) {
-        SystemFontPath = FontDir;
-        SystemFontPath += "\\Fonts\\";
+        std::wstringstream ss;
+        ss << winDir << "\\Fonts\\";
+        std::wstring wSystemFontPath = ss.str();
+        SystemFontPath = std::string(wSystemFontPath.begin(), wSystemFontPath.end());
     }
 #elif defined(__APPLE__)
     // System Fonts

--- a/src/fontmanager.cpp
+++ b/src/fontmanager.cpp
@@ -97,8 +97,15 @@ FontManager::FontManager() {
 
     // Set default font path
 #ifdef WIN32
-    WCHAR winDir[MAX_PATH];
-    const UINT success = GetWindowsDirectory(winDir, MAX_PATH);
+    #ifdef UNICODE
+    constexpr int BufferSize = MAX_PATH;
+    WCHAR winDir[BufferSize];
+    #else
+    constexpr int BufferSize = 256;
+    char winDir[BufferSize];
+    #endif // !UNICODE
+
+    const UINT success = GetWindowsDirectory(winDir, BufferSize);
 
     if (success > 0) {
         std::wstringstream ss;

--- a/src/fontmanager.cpp
+++ b/src/fontmanager.cpp
@@ -134,10 +134,11 @@ void FontManager::bindShader(const mat4& mvp, const vec4& color, int texture) co
     glUniformMatrix4fv(_mvpLocation, 1, GL_FALSE, mvp.values.data());
 }
 
-bool FontManager::addFont(std::string name, std::string file, bool absolutePath) {
+bool FontManager::addFont(std::string name, std::string file, bool isAbsolutePath) {
     // Perform file exists check
-    if(!absolutePath)
+    if (!isAbsolutePath) {
         file = SystemFontPath + file;
+    }
 
     const bool inserted = _fontPaths.insert({ name, std::move(file) }).second;
     if (!inserted) {

--- a/src/fontmanager.cpp
+++ b/src/fontmanager.cpp
@@ -97,22 +97,27 @@ FontManager::FontManager() {
 
     // Set default font path
 #ifdef WIN32
-    #ifdef UNICODE
+#ifdef UNICODE
     constexpr int BufferSize = MAX_PATH;
     WCHAR winDir[BufferSize];
-    #else
-    constexpr int BufferSize = 256;
-    char winDir[BufferSize];
-    #endif // !UNICODE
-
-    const UINT success = GetWindowsDirectory(winDir, BufferSize);
-
+    const UINT success = GetWindowsDirectoryW(winDir, BufferSize);
     if (success > 0) {
         std::wstringstream ss;
         ss << winDir << "\\Fonts\\";
         std::wstring wSystemFontPath = ss.str();
         SystemFontPath = std::string(wSystemFontPath.begin(), wSystemFontPath.end());
     }
+#else // !UNICODE
+    constexpr int BufferSize = 256;
+    char winDir[BufferSize];
+    const UINT success = GetWindowsDirectoryA(winDir, BufferSize);
+    if (success > 0) {
+        std::stringstream ss;
+        ss << winDir << "\\Fonts\\";
+        std::string wSystemFontPath = ss.str();
+        SystemFontPath = std::string(wSystemFontPath.begin(), wSystemFontPath.end());
+    }
+#endif // UNICODE
 #elif defined(__APPLE__)
     // System Fonts
     SystemFontPath = "/System/Library/Fonts/";


### PR DESCRIPTION
Should be the preffered way of finding path to system fonts on all win32 platforms.